### PR TITLE
[Team24][iOS] 수량 뷰 구현, 메소드 분리

### DIFF
--- a/iOS/SideDish-team24/SideDish-team24.xcodeproj/project.pbxproj
+++ b/iOS/SideDish-team24/SideDish-team24.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6C162B7B280ED461003399BC /* DeliverySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C162B7A280ED461003399BC /* DeliverySectionView.swift */; };
 		6C162B7D280ED8F9003399BC /* UILabelExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C162B7C280ED8F9003399BC /* UILabelExtension.swift */; };
 		6C4CEF4728110DD000AFB684 /* BriefBanchanViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4CEF4628110DD000AFB684 /* BriefBanchanViewControllerExtension.swift */; };
+		6C4CEF4B28111FA000AFB684 /* OrderCountSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4CEF4A28111FA000AFB684 /* OrderCountSectionView.swift */; };
 		6CEE0802280D080000D2D401 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEE0801280D080000D2D401 /* AppDelegate.swift */; };
 		6CEE0804280D080000D2D401 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEE0803280D080000D2D401 /* SceneDelegate.swift */; };
 		6CEE0806280D080000D2D401 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEE0805280D080000D2D401 /* MainViewController.swift */; };
@@ -38,6 +39,7 @@
 		6C162B7A280ED461003399BC /* DeliverySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliverySectionView.swift; sourceTree = "<group>"; };
 		6C162B7C280ED8F9003399BC /* UILabelExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelExtension.swift; sourceTree = "<group>"; };
 		6C4CEF4628110DD000AFB684 /* BriefBanchanViewControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BriefBanchanViewControllerExtension.swift; sourceTree = "<group>"; };
+		6C4CEF4A28111FA000AFB684 /* OrderCountSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCountSectionView.swift; sourceTree = "<group>"; };
 		6CEE07FE280D080000D2D401 /* SideDish-team24.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SideDish-team24.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6CEE0801280D080000D2D401 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6CEE0803280D080000D2D401 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 				6C105838280E7FD500C0B462 /* BriefBanchanReusableView.swift */,
 				F57135C1280E98500040C5A4 /* DetailBanchanBriefView.swift */,
 				6C162B7A280ED461003399BC /* DeliverySectionView.swift */,
+				6C4CEF4A28111FA000AFB684 /* OrderCountSectionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -297,6 +300,7 @@
 				6C105832280E6A0E00C0B462 /* UIColorExtension.swift in Sources */,
 				F5F1A1AA280E4736006EFDE2 /* DetailBanchanViewController.swift in Sources */,
 				6CEE0802280D080000D2D401 /* AppDelegate.swift in Sources */,
+				6C4CEF4B28111FA000AFB684 /* OrderCountSectionView.swift in Sources */,
 				6C162B7B280ED461003399BC /* DeliverySectionView.swift in Sources */,
 				6C10583B280E893100C0B462 /* CGFloatExtension.swift in Sources */,
 				F57135C2280E98500040C5A4 /* DetailBanchanBriefView.swift in Sources */,

--- a/iOS/SideDish-team24/SideDish-team24/Extension/UIColorExtension.swift
+++ b/iOS/SideDish-team24/SideDish-team24/Extension/UIColorExtension.swift
@@ -7,6 +7,7 @@ extension UIColor {
     static let dishWhite = UIColor(rgb: 0xFFFFFF)
     static let dishBlue = UIColor(rgb: 0x0066D6)
     static let dishSkyBlue = UIColor(rgb: 0x80BCFF)
+    static let dishGrey4 = UIColor(rgb: 0xF5F5F7)
     
     convenience init(red: Int, green: Int, blue: Int, alpha: CGFloat = 1.0) {
         assert(red >= 0 && red <= 255, "Invalid red component")

--- a/iOS/SideDish-team24/SideDish-team24/Extension/UIColorExtension.swift
+++ b/iOS/SideDish-team24/SideDish-team24/Extension/UIColorExtension.swift
@@ -8,6 +8,7 @@ extension UIColor {
     static let dishBlue = UIColor(rgb: 0x0066D6)
     static let dishSkyBlue = UIColor(rgb: 0x80BCFF)
     static let dishGrey4 = UIColor(rgb: 0xF5F5F7)
+    static let dishGrey3 = UIColor(rgb: 0xE0E0E0)
     
     convenience init(red: Int, green: Int, blue: Int, alpha: CGFloat = 1.0) {
         assert(red >= 0 && red <= 255, "Invalid red component")

--- a/iOS/SideDish-team24/SideDish-team24/View/BriefBanchanReusableView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/BriefBanchanReusableView.swift
@@ -17,15 +17,15 @@ class BriefBanchanReusableView: UICollectionReusableView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        layout()
+        layoutTitle()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        layout()
+        layoutTitle()
     }
     
-    private func layout() {
+    private func layoutTitle() {
         self.addSubview(self.title)
         NSLayoutConstraint.activate([
             self.title.topAnchor.constraint(equalTo: self.topAnchor),

--- a/iOS/SideDish-team24/SideDish-team24/View/BriefBanchanViewCell.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/BriefBanchanViewCell.swift
@@ -82,52 +82,59 @@ class BriefBanchanViewCell: UICollectionViewCell {
     }()
     
     override init(frame: CGRect) {
-        super.init(frame: frame)
-        self.layout()
+        super.init(frame:  frame)
+        self.layoutDishImage()
         self.layoutBreifStackView()
         self.layoutPriceStackView()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        self.layout()
+        self.layoutDishImage()
         self.layoutBreifStackView()
         self.layoutPriceStackView()
     }
-    
-    private func layout() {
+}
+
+private extension BriefBanchanViewCell {
+    func layoutDishImage() {
         self.addSubview(self.dishImage)
-        self.addSubview(self.breifStackView)
-        self.addSubview(self.specialPrice)
+        
         NSLayoutConstraint.activate([
             self.dishImage.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.dishImage.topAnchor.constraint(equalTo: self.topAnchor),
             self.dishImage.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             self.dishImage.widthAnchor.constraint(equalTo: self.heightAnchor, multiplier: 1),
-            
+        ])
+    }
+    
+    func layoutBreifStackView() {
+        self.addSubview(self.breifStackView)
+        
+        self.breifStackView.addArrangedSubview(self.dishTitle)
+        self.breifStackView.addArrangedSubview(self.dishDescription)
+        self.breifStackView.addArrangedSubview(self.prices)
+        
+        NSLayoutConstraint.activate([
             self.breifStackView.leadingAnchor.constraint(equalTo: self.dishImage.trailingAnchor, constant: CGFloat.defaultInset),
-            self.breifStackView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -CGFloat.defaultInset),
+            self.breifStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -CGFloat.defaultInset),
             self.breifStackView.topAnchor.constraint(equalTo: self.topAnchor, constant: CGFloat.defaultInset),
-            self.breifStackView.bottomAnchor.constraint(equalTo: self.specialPrice.topAnchor, constant: -CGFloat.defaultInset),
-            
+        ])
+    }
+    
+    func layoutPriceStackView() {
+        self.addSubview(self.specialPrice)
+        
+        self.prices.addArrangedSubview(self.discountPrice)
+        self.prices.addArrangedSubview(self.normalPrice)
+        
+        NSLayoutConstraint.activate([
+            self.specialPrice.topAnchor.constraint(equalTo: self.breifStackView.bottomAnchor, constant: CGFloat.defaultInset),
             self.specialPrice.leadingAnchor.constraint(equalTo: self.dishImage.trailingAnchor, constant: CGFloat.defaultInset),
             self.specialPrice.widthAnchor.constraint(equalTo: self.breifStackView.widthAnchor, multiplier: 0.3),
             self.specialPrice.heightAnchor.constraint(equalTo: self.breifStackView.heightAnchor, multiplier: 0.3),
             self.specialPrice.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -8),
         ])
-        
-    }
-    
-    private func layoutBreifStackView() {
-        self.breifStackView.addArrangedSubview(self.dishTitle)
-        self.breifStackView.addArrangedSubview(self.dishDescription)
-        self.breifStackView.addArrangedSubview(self.prices)
-    }
-    
-    private func layoutPriceStackView() {
-        self.prices.addArrangedSubview(self.discountPrice)
-        self.prices.addArrangedSubview(self.normalPrice)
-        self.prices.addArrangedSubview(self.blank)
         
         self.normalPrice.attributedText = self.normalPrice.text?.strikeThrough()
     }

--- a/iOS/SideDish-team24/SideDish-team24/View/DeliverySectionView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/DeliverySectionView.swift
@@ -30,40 +30,47 @@ class DeliverySectionView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.layout()
-        self.setSections()
+        self.layoutTitleSection()
+        self.layoutInformationSection()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        self.layout()
-        self.setSections()
+        self.layoutTitleSection()
+        self.layoutInformationSection()
     }
     
-    private func layout() {
+}
+
+private extension DeliverySectionView {
+    func layoutTitleSection() {
         self.addSubview(titleSection)
-        self.addSubview(informationSection)
+        
+        self.titleSection.addArrangedSubview(self.reserveTitle)
+        self.titleSection.addArrangedSubview(self.deliveryTitle)
+        self.titleSection.addArrangedSubview(self.deliveryFeeTitle)
         
         NSLayoutConstraint.activate([
             self.titleSection.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.titleSection.topAnchor.constraint(equalTo: self.topAnchor),
             self.titleSection.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             self.titleSection.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.2),
+        ])
+    }
+    
+    func layoutInformationSection() {
+        self.addSubview(informationSection)
+        
+        self.informationSection.addArrangedSubview(self.reserve)
+        self.informationSection.addArrangedSubview(self.deliveryInformation)
+        self.informationSection.addArrangedSubview(self.deliveryFee)
+        
+        NSLayoutConstraint.activate([
             self.informationSection.leadingAnchor.constraint(equalTo: self.titleSection.trailingAnchor, constant: CGFloat.defaultInset),
             self.informationSection.topAnchor.constraint(equalTo: self.topAnchor),
             self.informationSection.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             self.informationSection.trailingAnchor.constraint(equalTo: self.trailingAnchor),
         ])
-        
-    }
-    
-    private func setSections() {
-        self.titleSection.addArrangedSubview(self.reserveTitle)
-        self.titleSection.addArrangedSubview(self.deliveryTitle)
-        self.titleSection.addArrangedSubview(self.deliveryFeeTitle)
-        self.informationSection.addArrangedSubview(self.reserve)
-        self.informationSection.addArrangedSubview(self.deliveryInformation)
-        self.informationSection.addArrangedSubview(self.deliveryFee)
     }
     
 }

--- a/iOS/SideDish-team24/SideDish-team24/View/DetailBanchanBriefView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/DetailBanchanBriefView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class DetailBanchanBriefView: UIView {
-
+    
     // 스크롤 뷰(좌우)
     private var dishImage: UIImageView = {
         let imageView = UIImageView()
@@ -82,19 +82,22 @@ class DetailBanchanBriefView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.layout()
+        self.layoutDishImage()
         self.layoutBreifStackView()
         self.layoutPriceStackView()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        self.layout()
+        self.layoutDishImage()
         self.layoutBreifStackView()
         self.layoutPriceStackView()
     }
     
-    private func layout() {
+}
+
+private extension DetailBanchanBriefView {
+    func layoutDishImage() {
         self.addSubview(self.dishImage)
         self.addSubview(self.breifStackView)
         self.addSubview(self.specialPrice)
@@ -103,32 +106,34 @@ class DetailBanchanBriefView: UIView {
             self.dishImage.topAnchor.constraint(equalTo: self.topAnchor),
             self.dishImage.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             self.dishImage.heightAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1),
-            
+        ])
+    }
+    
+    func layoutBreifStackView() {
+        self.breifStackView.addArrangedSubview(self.dishTitle)
+        self.breifStackView.addArrangedSubview(self.dishDescription)
+        self.breifStackView.addArrangedSubview(self.prices)
+        
+        NSLayoutConstraint.activate([
             self.breifStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.breifStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             self.breifStackView.topAnchor.constraint(equalTo: self.dishImage.bottomAnchor),
-            self.breifStackView.bottomAnchor.constraint(equalTo: self.specialPrice.topAnchor),
-            
+        ])
+    }
+    
+    func layoutPriceStackView() {
+        self.prices.addArrangedSubview(self.discountPrice)
+        self.prices.addArrangedSubview(self.normalPrice)
+        self.prices.addArrangedSubview(self.blank)
+        
+        NSLayoutConstraint.activate([
+            self.specialPrice.topAnchor.constraint(equalTo: self.breifStackView.bottomAnchor),
             self.specialPrice.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.specialPrice.widthAnchor.constraint(equalTo: self.breifStackView.widthAnchor, multiplier: 0.3),
             self.specialPrice.heightAnchor.constraint(equalTo: self.breifStackView.heightAnchor, multiplier: 0.3),
             self.specialPrice.bottomAnchor.constraint(equalTo: self.bottomAnchor),
         ])
         
-    }
-    
-    private func layoutBreifStackView() {
-        self.breifStackView.addArrangedSubview(self.dishTitle)
-        self.breifStackView.addArrangedSubview(self.dishDescription)
-        self.breifStackView.addArrangedSubview(self.prices)
-    }
-    
-    private func layoutPriceStackView() {
-        self.prices.addArrangedSubview(self.discountPrice)
-        self.prices.addArrangedSubview(self.normalPrice)
-        self.prices.addArrangedSubview(self.blank)
-        
         self.normalPrice.attributedText = self.normalPrice.text?.strikeThrough()
     }
-
 }

--- a/iOS/SideDish-team24/SideDish-team24/View/DetailBanchanBriefView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/DetailBanchanBriefView.swift
@@ -104,15 +104,15 @@ class DetailBanchanBriefView: UIView {
             self.dishImage.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             self.dishImage.heightAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1),
             
-            self.breifStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: CGFloat.defaultInset),
-            self.breifStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -CGFloat.defaultInset),
-            self.breifStackView.topAnchor.constraint(equalTo: self.dishImage.bottomAnchor, constant: CGFloat.defaultInset),
-            self.breifStackView.bottomAnchor.constraint(equalTo: self.specialPrice.topAnchor, constant: -CGFloat.defaultInset),
+            self.breifStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.breifStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.breifStackView.topAnchor.constraint(equalTo: self.dishImage.bottomAnchor),
+            self.breifStackView.bottomAnchor.constraint(equalTo: self.specialPrice.topAnchor),
             
-            self.specialPrice.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: CGFloat.defaultInset),
+            self.specialPrice.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             self.specialPrice.widthAnchor.constraint(equalTo: self.breifStackView.widthAnchor, multiplier: 0.3),
             self.specialPrice.heightAnchor.constraint(equalTo: self.breifStackView.heightAnchor, multiplier: 0.3),
-            self.specialPrice.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -8),
+            self.specialPrice.bottomAnchor.constraint(equalTo: self.bottomAnchor),
         ])
         
     }

--- a/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
@@ -18,7 +18,10 @@ class OrderCountSectionView: UIView {
        let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
-        stackView.distribution = .fillEqually
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.layer.cornerRadius = 5
+        stackView.clipsToBounds = true
         return stackView
     }()
     
@@ -30,6 +33,13 @@ class OrderCountSectionView: UIView {
         button.setTitleColor(UIColor.black, for: .normal)
         button.backgroundColor = UIColor.dishGrey4
         return button
+    }()
+    
+    private var separator: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor.dishGrey3
+        return view
     }()
     
     private var plusButton: UIButton = {
@@ -70,7 +80,7 @@ class OrderCountSectionView: UIView {
         self.addSubview(counter)
         
         NSLayoutConstraint.activate([
-            self.counter.leadingAnchor.constraint(greaterThanOrEqualTo: self.countTitle.trailingAnchor, constant: 0),
+            self.counter.leadingAnchor.constraint(greaterThanOrEqualTo: self.countTitle.trailingAnchor, constant:  10),
             self.counter.topAnchor.constraint(equalTo: self.topAnchor),
             self.counter.bottomAnchor.constraint(equalTo: self.bottomAnchor),
         ])
@@ -79,13 +89,20 @@ class OrderCountSectionView: UIView {
     private func layoutButtons() {
         self.addSubview(buttons)
         self.buttons.addArrangedSubview(minusButton)
+        self.buttons.addArrangedSubview(separator)
         self.buttons.addArrangedSubview(plusButton)
         
         NSLayoutConstraint.activate([
-            self.buttons.leadingAnchor.constraint(equalTo: self.counter.trailingAnchor),
+            self.buttons.heightAnchor.constraint(equalToConstant: 28),
+            self.buttons.leadingAnchor.constraint(equalTo: self.counter.trailingAnchor, constant: CGFloat.defaultInset*3),
             self.buttons.topAnchor.constraint(equalTo: self.topAnchor),
             self.buttons.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            self.buttons.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+            self.buttons.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.buttons.widthAnchor.constraint(equalToConstant: 100),
+            
+            self.minusButton.widthAnchor.constraint(equalTo: self.plusButton.widthAnchor),
+            self.separator.widthAnchor.constraint(equalToConstant: 1),
+            self.separator.heightAnchor.constraint(equalTo: self.buttons.heightAnchor, multiplier: 0.6)
         ])
     }
 }

--- a/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class OrderCountSectionView: UIView {
-
+    
     private var countTitle: UILabel = {
         let label = UILabel.customLabel("수량", UIColor.dishLightGrey)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -15,7 +15,7 @@ class OrderCountSectionView: UIView {
     }()
     
     private var buttons: UIStackView = {
-       let stackView = UIStackView()
+        let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.distribution = .fill
@@ -65,8 +65,10 @@ class OrderCountSectionView: UIView {
         self.layoutCounter()
         self.layoutButtons()
     }
-    
-    private func layoutCountTitle() {
+}
+
+private extension OrderCountSectionView {
+    func layoutCountTitle() {
         self.addSubview(countTitle)
         
         NSLayoutConstraint.activate([
@@ -76,7 +78,7 @@ class OrderCountSectionView: UIView {
         ])
     }
     
-    private func layoutCounter() {
+    func layoutCounter() {
         self.addSubview(counter)
         
         NSLayoutConstraint.activate([
@@ -86,7 +88,7 @@ class OrderCountSectionView: UIView {
         ])
     }
     
-    private func layoutButtons() {
+    func layoutButtons() {
         self.addSubview(buttons)
         self.buttons.addArrangedSubview(minusButton)
         self.buttons.addArrangedSubview(separator)

--- a/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
@@ -1,0 +1,91 @@
+import UIKit
+
+class OrderCountSectionView: UIView {
+
+    private var countTitle: UILabel = {
+        let label = UILabel.customLabel("수량", UIColor.dishLightGrey)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private var counter: UILabel = {
+        let label = UILabel.customLabel("1", UIColor.dishGrey)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private var buttons: UIStackView = {
+       let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+    
+    private var minusButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("-", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 17)
+        button.setTitleColor(UIColor.black, for: .normal)
+        button.backgroundColor = UIColor.dishGrey4
+        return button
+    }()
+    
+    private var plusButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("+", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 17)
+        button.setTitleColor(UIColor.black, for: .normal)
+        button.backgroundColor = UIColor.dishGrey4
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.layoutCountTitle()
+        self.layoutCounter()
+        self.layoutButtons()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.layoutCountTitle()
+        self.layoutCounter()
+        self.layoutButtons()
+    }
+    
+    private func layoutCountTitle() {
+        self.addSubview(countTitle)
+        
+        NSLayoutConstraint.activate([
+            self.countTitle.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.countTitle.topAnchor.constraint(equalTo: self.topAnchor),
+            self.countTitle.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        ])
+    }
+    
+    private func layoutCounter() {
+        self.addSubview(counter)
+        
+        NSLayoutConstraint.activate([
+            self.counter.leadingAnchor.constraint(greaterThanOrEqualTo: self.countTitle.trailingAnchor, constant: 0),
+            self.counter.topAnchor.constraint(equalTo: self.topAnchor),
+            self.counter.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        ])
+    }
+    
+    private func layoutButtons() {
+        self.addSubview(buttons)
+        self.buttons.addArrangedSubview(minusButton)
+        self.buttons.addArrangedSubview(plusButton)
+        
+        NSLayoutConstraint.activate([
+            self.buttons.leadingAnchor.constraint(equalTo: self.counter.trailingAnchor),
+            self.buttons.topAnchor.constraint(equalTo: self.topAnchor),
+            self.buttons.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.buttons.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+    }
+}

--- a/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
+++ b/iOS/SideDish-team24/SideDish-team24/View/OrderCountSectionView.swift
@@ -2,6 +2,8 @@ import UIKit
 
 class OrderCountSectionView: UIView {
     
+    private var count = 1
+    
     private var countTitle: UILabel = {
         let label = UILabel.customLabel("수량", UIColor.dishLightGrey)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -32,6 +34,7 @@ class OrderCountSectionView: UIView {
         button.titleLabel?.font = UIFont.systemFont(ofSize: 17)
         button.setTitleColor(UIColor.black, for: .normal)
         button.backgroundColor = UIColor.dishGrey4
+        button.isEnabled = false
         return button
     }()
     
@@ -68,6 +71,22 @@ class OrderCountSectionView: UIView {
 }
 
 private extension OrderCountSectionView {
+    @objc func plusButtonTouched(_ sender: UIButton) {
+        self.count += 1
+        self.counter.text = "\(self.count)"
+        if self.count > 1 {
+            self.minusButton.isEnabled = true
+        }
+    }
+    
+    @objc func minusButtonTouched(_ sender: UIButton) {
+        self.count -= 1
+        self.counter.text = "\(self.count)"
+        if self.count == 1 {
+            self.minusButton.isEnabled = false
+        }
+    }
+    
     func layoutCountTitle() {
         self.addSubview(countTitle)
         
@@ -93,6 +112,10 @@ private extension OrderCountSectionView {
         self.buttons.addArrangedSubview(minusButton)
         self.buttons.addArrangedSubview(separator)
         self.buttons.addArrangedSubview(plusButton)
+        
+        self.plusButton.addTarget(self, action: #selector(plusButtonTouched(_:)), for: .touchUpInside)
+        
+        self.minusButton.addTarget(self, action: #selector(minusButtonTouched(_:)), for: .touchUpInside)
         
         NSLayoutConstraint.activate([
             self.buttons.heightAnchor.constraint(equalToConstant: 28),

--- a/iOS/SideDish-team24/SideDish-team24/ViewController/BriefBanchanViewController.swift
+++ b/iOS/SideDish-team24/SideDish-team24/ViewController/BriefBanchanViewController.swift
@@ -9,8 +9,6 @@ class BriefBanchanViewController: UIViewController, UIGestureRecognizerDelegate 
         
         self.registerCollectionView()
     }
-    
-    
 }
 
 private extension BriefBanchanViewController {

--- a/iOS/SideDish-team24/SideDish-team24/ViewController/DetailBanchanViewController.swift
+++ b/iOS/SideDish-team24/SideDish-team24/ViewController/DetailBanchanViewController.swift
@@ -16,6 +16,7 @@ class DetailBanchanViewController: UIViewController {
     
     private let banchanBrief = DetailBanchanBriefView()
     private let deliverySection = DeliverySectionView()
+    private let counterSection = OrderCountSectionView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,6 +43,7 @@ private extension DetailBanchanViewController {
         
         self.innerView.addArrangedSubview(banchanBrief)
         self.innerView.addArrangedSubview(deliverySection)
+        self.innerView.addArrangedSubview(counterSection)
         NSLayoutConstraint.activate([
             self.innerView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
             self.innerView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),

--- a/iOS/SideDish-team24/SideDish-team24/ViewController/DetailBanchanViewController.swift
+++ b/iOS/SideDish-team24/SideDish-team24/ViewController/DetailBanchanViewController.swift
@@ -20,13 +20,14 @@ class DetailBanchanViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.layout()
+        self.layoutScollView()
+        self.layoutInnerView()
     }
     
 }
 
 private extension DetailBanchanViewController {
-    func layout() {
+    func layoutScollView() {
         let safeArea = self.view.safeAreaLayoutGuide
         self.view.addSubview(scrollView)
         self.scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -38,6 +39,10 @@ private extension DetailBanchanViewController {
             self.scrollView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
         ])
         
+        
+    }
+    
+    func layoutInnerView() {
         self.scrollView.addSubview(innerView)
         self.innerView.translatesAutoresizingMaskIntoConstraints = false
         

--- a/iOS/SideDish-team24/SideDish-team24/ViewController/DetailBanchanViewController.swift
+++ b/iOS/SideDish-team24/SideDish-team24/ViewController/DetailBanchanViewController.swift
@@ -47,9 +47,9 @@ private extension DetailBanchanViewController {
         NSLayoutConstraint.activate([
             self.innerView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
             self.innerView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-            self.innerView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            self.innerView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
-            self.innerView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            self.innerView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: CGFloat.defaultInset),
+            self.innerView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -CGFloat.defaultInset),
+            self.innerView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -CGFloat.defaultInset*2),
             self.innerView.heightAnchor.constraint(greaterThanOrEqualToConstant: self.view.frame.height),
         ])
     }


### PR DESCRIPTION
안녕하세요 쑤 !
dale, Ocean 입니다!
목요일에 처음으로 오프라인 공간에 나가서 너무 즐거웠던 나머지,, 리뷰해주실 내용이 별로없네요😅

# 작업내용 
- [x] 수량 표시 뷰 구현
- [x] 뷰 별로 레이아웃 분리
- [x] private 메소드 private extension으로 분리

# 고민과 해결
- 저번 리뷰에서 알려주신 content hugging priority, compression resistance 키워드에 대해서 학습후 stackView 안에서 적용해보려고 했더니 적용이 잘 되지않았습니다. 저희가 판단한 원인은 해당 스택뷰의 distribution을 설정해놓아서 그렇다고 생각을 했습니다. 아직 해당 부분에 대해서 확실하게 적용은 하지못했지만 조금더 삽질해보고 꼭 적용해보도록 하겠습니다!

# 질문
- +, -  버튼 터치시 `counter.text` 를 변경시켜주기위해  `count: Int` 변수를 선언한후 해당 변수를 뷰에서 사용하고 있습니다. 뷰가 이런 정보를 담고있는건 좋지않은것 같다고 생각을 하는데 이런 사소한 부분도 모델을 따로 만들어서 활용해야 하는지 궁금합니다!

# 실행화면
<img src="https://user-images.githubusercontent.com/78553659/164591460-b841fccc-0cae-4f6e-94e9-4e5b42e3368b.gif" width=300 height=600 />