### PR TITLE
[Team-29][Android] 피드백 반영 및 상세 화면 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # sidedish
 그룹 프로젝트 #2
+
+팀원 
+|Android|Github|
+|-|-|
+|wooki|[banjjak2](https://github.com/banjjak2)|
+|Jay|[shim506](https://github.com/shim506)|
+
+***
+## GroundRule
+
+[프로젝트 GroundRule(코어타임, 브랜치 전략, 깃허브 세팅, 커밋 컨벤션)](https://www.notion.so/GroundRule-06f6e41e33164dd7b4c8fd2eb86463c3)
+
+***
+## Android 기능 정리
+[기능별 계획](https://www.notion.so/Android-58616423619c40d5a53e2b4fa3d41154)
+
+***
+## 회의록
+[4/19](https://www.notion.so/890b36822c6646669695bde9eaa7b526#de8c3a917cd2472b99e01819e3ef0785)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,6 @@ android {
 
 dependencies {
     implementation "androidx.fragment:fragment-ktx:1.4.1"
-
     implementation 'com.github.bumptech.glide:glide:4.13.0'
     implementation "androidx.viewpager2:viewpager2:1.0.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,7 @@ android {
 }
 
 dependencies {
+    implementation "androidx.fragment:fragment-ktx:1.4.1"
 
     implementation 'com.github.bumptech.glide:glide:4.13.0'
     implementation "androidx.viewpager2:viewpager2:1.0.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.SideDish">
         <activity
+
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/example/sideDish/MainActivity.kt
+++ b/app/src/main/java/com/example/sideDish/MainActivity.kt
@@ -2,15 +2,10 @@ package com.example.sideDish
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.example.sideDish.ui.foodlist.FoodListFragment
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        val transaction = supportFragmentManager.beginTransaction()
-        transaction.add(R.id.container, FoodListFragment())
-        transaction.commit()
     }
 }

--- a/app/src/main/java/com/example/sideDish/MainActivity.kt
+++ b/app/src/main/java/com/example/sideDish/MainActivity.kt
@@ -1,16 +1,33 @@
 package com.example.sideDish
 
 import android.os.Bundle
+import android.os.PersistableBundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
 import com.example.sideDish.ui.foodlist.FoodListFragment
+import com.example.sideDish.ui.productdetail.ProductDetailFragment
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val transaction = supportFragmentManager.beginTransaction()
-        transaction.add(R.id.container, FoodListFragment())
-        transaction.commit()
+
+        if (savedInstanceState != null) {
+            val lastFragment = savedInstanceState.getInt("lastFragment")
+
+            if (lastFragment == 1) supportFragmentManager.commit {
+                replace(
+                    R.id.container,
+                    ProductDetailFragment()
+                )
+            }
+            else if (lastFragment == 2) supportFragmentManager.commit {
+                replace(
+                    R.id.container,
+                    FoodListFragment()
+                )
+            }
+        } else supportFragmentManager.commit { replace(R.id.container, FoodListFragment()) }
     }
 }

--- a/app/src/main/java/com/example/sideDish/common/ViewModelFactory.kt
+++ b/app/src/main/java/com/example/sideDish/common/ViewModelFactory.kt
@@ -4,13 +4,20 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.example.sideDish.data.source.FoodRepository
 import com.example.sideDish.ui.foodlist.FoodListViewModel
+import com.example.sideDish.ui.productdetail.FoodDetailViewModel
 
-class ViewModelFactory(private val repository: FoodRepository) : ViewModelProvider.Factory {
+class ViewModelFactory(private val repository: FoodRepository , private val hash:String ="") : ViewModelProvider.Factory {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        return if (modelClass.isAssignableFrom(FoodListViewModel::class.java)) {
-            FoodListViewModel(repository) as T
-        } else {
-            throw IllegalArgumentException()
+        return when {
+            modelClass.isAssignableFrom(FoodListViewModel::class.java) -> {
+                FoodListViewModel(repository) as T
+            }
+            modelClass.isAssignableFrom(FoodDetailViewModel::class.java) -> {
+                FoodDetailViewModel(repository , hash) as T
+            }
+            else -> {
+                throw IllegalArgumentException()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/sideDish/data/FoodCategory.kt
+++ b/app/src/main/java/com/example/sideDish/data/FoodCategory.kt
@@ -1,7 +1,7 @@
 package com.example.sideDish.data
 
-enum class FoodCategory {
-    MAIN,
-    SOUP,
-    SIDE
+enum class FoodCategory(val sectionTitle: String) {
+    MAIN("모두가 좋아하는\n든든한 메인 요리"),
+    SOUP("정성이 담긴\n뜨끈뜨근 국물요리"),
+    SIDE("식탁을 풍성하게 하는\n정갈한 밑반찬")
 }

--- a/app/src/main/java/com/example/sideDish/data/source/FoodDetail.kt
+++ b/app/src/main/java/com/example/sideDish/data/source/FoodDetail.kt
@@ -1,0 +1,13 @@
+package com.example.sideDish.data.source
+
+class FoodDetail(
+    val deliveryFee: String,
+    val deliveryInfo: String,
+    val detailImageUrls: List<String>,
+    val point: String,
+    val originalPrice: Int,
+    val discountedPrice: Int,
+    val productDescription: String,
+    val thumbImageUrls: List<String>,
+    val topImageUrl: String
+)

--- a/app/src/main/java/com/example/sideDish/data/source/FoodRepository.kt
+++ b/app/src/main/java/com/example/sideDish/data/source/FoodRepository.kt
@@ -4,6 +4,28 @@ import com.example.sideDish.data.FoodCategory
 import com.example.sideDish.data.Item
 
 class FoodRepository {
+    fun getFoodDetail(hash: String): FoodDetail {
+        return FoodDetail(
+            "2,500원 (40,000원 이상 구매 시 무료)",
+            "서울 경기 새벽 배송, 전국 택배 배송",
+            listOf(
+                "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_D1.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_D2.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/pakage_regular.jpg"
+            ),
+            "126원",
+            15800,
+            12640,
+            "오리 주물럭_반조리",
+            listOf(
+                "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_S.jpg"
+            ),
+
+            "http://public.codesquad.kr/jk/storeapp/data/1155_ZIP_P_0081_T.jpg"
+        )
+    }
+
     fun getMainItems(): List<Item> {
         return listOf(
             Item.Section(FoodCategory.MAIN),

--- a/app/src/main/java/com/example/sideDish/ui/BindingAdapters.kt
+++ b/app/src/main/java/com/example/sideDish/ui/BindingAdapters.kt
@@ -3,6 +3,7 @@ package com.example.sideDish.ui
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
+import com.example.sideDish.ui.productdetail.FoodDetailViewModel
 
 @BindingAdapter("image")
 fun setImage(view: ImageView, url: String?) {
@@ -11,4 +12,14 @@ fun setImage(view: ImageView, url: String?) {
             .load(url)
             .into(view)
     }
+}
+
+@BindingAdapter("count")
+fun setCount(view: Stepper, count: Int) {
+    view.count = count
+}
+
+@BindingAdapter("viewModel")
+fun setViewModel(view: Stepper, viewModel: FoodDetailViewModel) {
+    view.viewModel = viewModel
 }

--- a/app/src/main/java/com/example/sideDish/ui/Stepper.kt
+++ b/app/src/main/java/com/example/sideDish/ui/Stepper.kt
@@ -7,17 +7,31 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import com.example.sideDish.R
+import com.example.sideDish.ui.productdetail.FoodDetailViewModel
 
 class Stepper(context: Context, attrs: AttributeSet) :
     LinearLayout(context, attrs) {
     lateinit var plus: ImageButton
     lateinit var value: TextView
     lateinit var minus: ImageButton
+    var viewModel: FoodDetailViewModel? = null
+    var count: Int = 0
 
     init {
         LayoutInflater.from(context).inflate(R.layout.stepper, this, true)
         plus = findViewById(R.id.button_stepper_plus)
         value = findViewById(R.id.text_view_stepper_value)
         minus = findViewById(R.id.button_stepper_minus)
+
+        value.text = count.toString()
+
+        plus.setOnClickListener {
+            viewModel?.orderCount?.value = viewModel?.orderCount?.value?.plus(1)
+        }
+        minus.setOnClickListener {
+            viewModel?.orderCount?.value = viewModel?.orderCount?.value?.minus(1)
+        }
     }
+
+
 }

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
@@ -1,6 +1,7 @@
 package com.example.sideDish.ui.foodlist
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DiffUtil
@@ -21,6 +22,11 @@ class FoodListAdapter(private val viewModel: FoodListViewModel) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(section: Item.Section) {
             binding.sectionText.text = section.category.sectionTitle
+            binding.sectionText.setOnClickListener {
+                binding.sectionCountText.visibility = View.VISIBLE
+                val count = viewModel.getCategoryItemsCount(section.category)
+                binding.sectionCountText.text = String.format("총 %d개의 상품이 등록되어 있습니다.", count)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
@@ -59,7 +59,7 @@ class FoodListAdapter(private val viewModel: FoodListViewModel) :
                     )
                 )
             }
-            else -> throw Exception("View Type을 찾을 수 없습니다.")
+            else -> error("View Type을 찾을 수 없습니다.")
         }
     }
 

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
@@ -20,11 +20,7 @@ class FoodListAdapter(private val viewModel: FoodListViewModel) :
     inner class SectionViewHolder(private val binding: SectionBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(section: Item.Section) {
-            binding.sectionText.text = when (section.category) {
-                FoodCategory.MAIN -> "모두가 좋아하는\n든든한 메인 요리"
-                FoodCategory.SOUP -> "정성이 담긴\n뜨끈뜨근 국물요리"
-                FoodCategory.SIDE -> "식탁을 풍성하게 하는\n정갈한 밑반찬"
-            }
+            binding.sectionText.text = section.category.sectionTitle
         }
     }
 

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListAdapter.kt
@@ -3,6 +3,8 @@ package com.example.sideDish.ui.foodlist
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sideDish.R
 import com.example.sideDish.data.FoodCategory
@@ -14,9 +16,7 @@ private const val VIEW_TYPE_SECTION = 1
 private const val VIEW_TYPE_CONTENT = 2
 
 class FoodListAdapter(private val viewModel: FoodListViewModel) :
-    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private val items = mutableListOf<Item>()
-
+    ListAdapter<Item, RecyclerView.ViewHolder>(diffUtil) {
     inner class SectionViewHolder(private val binding: SectionBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(section: Item.Section) {
@@ -29,7 +29,7 @@ class FoodListAdapter(private val viewModel: FoodListViewModel) :
         fun bind(foodInfo: Item.FoodInfo) = with(binding) {
             binding.foodInfo = foodInfo
             binding.viewmodel = viewModel
-            executePendingBindings()
+//            executePendingBindings()
         }
     }
 
@@ -62,56 +62,38 @@ class FoodListAdapter(private val viewModel: FoodListViewModel) :
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is SectionViewHolder -> {
-                holder.bind(items[position] as Item.Section)
+                holder.bind(getItem(position) as Item.Section)
             }
             is SummaryItemViewHolder -> {
-                holder.bind(items[position] as Item.FoodInfo)
+                holder.bind(getItem(position) as Item.FoodInfo)
             }
         }
     }
 
     override fun getItemViewType(position: Int): Int {
-        return when (items[position]) {
+        return when (getItem(position)) {
             is Item.Section -> VIEW_TYPE_SECTION
             is Item.FoodInfo -> VIEW_TYPE_CONTENT
         }
     }
 
-    override fun getItemCount(): Int {
-        return items.size
+    fun updateCategoryItems(category: FoodCategory) {
+        viewModel.updateItems(category)
+    }
+}
+
+private val diffUtil = object : DiffUtil.ItemCallback<Item>() {
+    override fun areItemsTheSame(oldItem: Item, newItem: Item): Boolean {
+        return when (oldItem) {
+            is Item.Section -> oldItem == (newItem as? Item.Section) ?: false
+            is Item.FoodInfo -> oldItem == (newItem as? Item.FoodInfo) ?: false
+        }
     }
 
-    fun setItems(category: FoodCategory, newItems: List<Item>) {
-        var sectionIndex = -1
-        items.forEachIndexed { itemIndex, item ->
-            when (item) {
-                is Item.Section -> {
-                    if (item.category == category) {
-                        sectionIndex = itemIndex
-                        return@forEachIndexed
-                    }
-                }
-                else -> {}
-            }
-        }
-        if (sectionIndex == -1) {
-            items.addAll(newItems)
-
-            notifyItemRangeChanged(items.size + 1, newItems.size)
-        } else {
-            var removedIndex = 0
-            for (index in sectionIndex + 1 until items.size) {
-                when (items[index]) {
-                    is Item.Section -> break
-                    else -> removedIndex++
-                }
-            }
-
-            items.removeAll(items.slice(sectionIndex + 1..sectionIndex + removedIndex))
-            items.addAll(sectionIndex + 1, newItems)
-
-            notifyItemRangeRemoved(sectionIndex + 1, removedIndex)
-            notifyItemRangeChanged(sectionIndex + 1, newItems.size)
+    override fun areContentsTheSame(oldItem: Item, newItem: Item): Boolean {
+        return when (oldItem) {
+            is Item.Section -> oldItem.category == (newItem as? Item.Section)?.category ?: false
+            is Item.FoodInfo -> oldItem.detailHash == (newItem as? Item.FoodInfo)?.detailHash ?: false
         }
     }
 }

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListFragment.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListFragment.kt
@@ -8,8 +8,8 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.example.sideDish.common.EventObserver
 import com.example.sideDish.R
+import com.example.sideDish.common.EventObserver
 import com.example.sideDish.common.ViewModelFactory
 import com.example.sideDish.data.FoodCategory
 import com.example.sideDish.data.source.FoodRepository
@@ -19,7 +19,6 @@ class FoodListFragment : Fragment() {
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var viewModel: FoodListViewModel
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -28,34 +27,30 @@ class FoodListFragment : Fragment() {
         recyclerView = layout.findViewById(R.id.recyclerview)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         viewModel = ViewModelProvider(
-            this,
+            requireActivity(),
             ViewModelFactory(FoodRepository())
         ).get(FoodListViewModel::class.java)
 
+        return layout
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val adapter = FoodListAdapter(viewModel)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
 
-        viewModel.mainItems.observe(viewLifecycleOwner) {
-            adapter.setItems(FoodCategory.MAIN, it)
+        viewModel.items.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
         }
 
-        viewModel.soupItems.observe(viewLifecycleOwner) {
-            adapter.setItems(FoodCategory.SOUP, it)
-        }
-
-        viewModel.sideItems.observe(viewLifecycleOwner) {
-            adapter.setItems(FoodCategory.SIDE, it)
-        }
-
-        viewModel.getMainItems()
-        viewModel.getSoupItems()
-        viewModel.getSideItems()
+        adapter.updateCategoryItems(FoodCategory.MAIN)
+        adapter.updateCategoryItems(FoodCategory.SOUP)
+        adapter.updateCategoryItems(FoodCategory.SIDE)
 
         viewModel.openDetail.observe(viewLifecycleOwner, EventObserver {
             openDetail()
         })
-
-        return layout
     }
 
     private fun openDetail() {

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListFragment.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -14,6 +15,7 @@ import com.example.sideDish.common.ViewModelFactory
 import com.example.sideDish.data.FoodCategory
 import com.example.sideDish.data.source.FoodRepository
 import com.example.sideDish.ui.productdetail.ProductDetailFragment
+import kotlin.concurrent.fixedRateTimer
 
 class FoodListFragment : Fragment() {
 
@@ -59,9 +61,9 @@ class FoodListFragment : Fragment() {
     }
 
     private fun openDetail() {
-        val transaction = parentFragmentManager.beginTransaction()
-        transaction.replace(R.id.container, ProductDetailFragment())
-        transaction.addToBackStack(null)
-        transaction.commit()
+        parentFragmentManager.commit {
+            addToBackStack(null)
+            replace(R.id.container, ProductDetailFragment())
+        }
     }
 }

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListViewModel.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListViewModel.kt
@@ -4,35 +4,69 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.sideDish.common.Event
+import com.example.sideDish.data.FoodCategory
 import com.example.sideDish.data.Item
 import com.example.sideDish.data.source.FoodRepository
 
 class FoodListViewModel(private val repository: FoodRepository) : ViewModel() {
-    private val _mainItems = MutableLiveData<List<Item>>()
-    val mainItems: LiveData<List<Item>> = _mainItems
-
-    private val _soupItems = MutableLiveData<List<Item>>()
-    val soupItems: LiveData<List<Item>> = _soupItems
-
-    private val _sideItems = MutableLiveData<List<Item>>()
-    val sideItems: LiveData<List<Item>> = _sideItems
-
     private val _openDetail = MutableLiveData<Event<Boolean>>()
     val openDetail: LiveData<Event<Boolean>> = _openDetail
 
-    fun getMainItems() {
-        _mainItems.value = repository.getMainItems()
+    private val _items = MutableLiveData<List<Item>>()
+    val items: LiveData<List<Item>> = _items
+
+    private fun getMainItems(): List<Item> {
+        return repository.getMainItems()
     }
 
-    fun getSoupItems() {
-        _soupItems.value = repository.getSoupItems()
+    private fun getSoupItems(): List<Item> {
+        return repository.getSoupItems()
     }
 
-    fun getSideItems() {
-        _sideItems.value = repository.getSideItems()
+    private fun getSideItems(): List<Item> {
+        return repository.getSideItems()
     }
 
     fun openDetail() {
         _openDetail.value = Event(true)
+    }
+
+    fun updateItems(category: FoodCategory) {
+        val tempItems = _items.value?.toMutableList() ?: mutableListOf()
+        val newItems = when (category) {
+            FoodCategory.MAIN -> getMainItems()
+            FoodCategory.SOUP -> getSoupItems()
+            FoodCategory.SIDE -> getSideItems()
+        }
+
+        var sectionIndex = -1
+        tempItems.forEachIndexed { itemIndex, item ->
+            when (item) {
+                is Item.Section -> {
+                    if (item.category == category) {
+                        sectionIndex = itemIndex
+                        return@forEachIndexed
+                    }
+                }
+                else -> {}
+            }
+        }
+
+        if (sectionIndex == -1) {
+            tempItems.addAll(newItems)
+        } else {
+            var removedIndex = 0
+            for (index in sectionIndex + 1 until tempItems.size) {
+                when (tempItems[index]) {
+                    is Item.Section -> break
+                    else -> removedIndex++
+                }
+            }
+
+            tempItems.removeAll(tempItems.slice(sectionIndex..sectionIndex + removedIndex))
+            tempItems.addAll(sectionIndex, newItems)
+        }
+
+        _items.value = tempItems.toList()
     }
 }

--- a/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListViewModel.kt
+++ b/app/src/main/java/com/example/sideDish/ui/foodlist/FoodListViewModel.kt
@@ -15,20 +15,40 @@ class FoodListViewModel(private val repository: FoodRepository) : ViewModel() {
     private val _items = MutableLiveData<List<Item>>()
     val items: LiveData<List<Item>> = _items
 
+    private var mainItemsCount = 0
+    private var soupItemsCount = 0
+    private var sideItemsCount = 0
+
     private fun getMainItems(): List<Item> {
-        return repository.getMainItems()
+        val mainItems = repository.getMainItems()
+        mainItemsCount = mainItems.size
+        return mainItems
     }
 
     private fun getSoupItems(): List<Item> {
-        return repository.getSoupItems()
+        val soupItems = repository.getSoupItems()
+        soupItemsCount = soupItems.size
+        return soupItems
     }
 
     private fun getSideItems(): List<Item> {
-        return repository.getSideItems()
+        val sideItems = repository.getSideItems()
+        sideItemsCount = sideItems.size
+        return sideItems
     }
 
     fun openDetail() {
         _openDetail.value = Event(true)
+    }
+
+    fun getCategoryItemsCount(category: FoodCategory): Int {
+        val count = when (category) {
+            FoodCategory.MAIN -> mainItemsCount
+            FoodCategory.SOUP -> soupItemsCount
+            FoodCategory.SIDE -> sideItemsCount
+        }
+        return if (count == 0) 0
+        else count - 1
     }
 
     fun updateItems(category: FoodCategory) {

--- a/app/src/main/java/com/example/sideDish/ui/productdetail/FoodDetailViewModel.kt
+++ b/app/src/main/java/com/example/sideDish/ui/productdetail/FoodDetailViewModel.kt
@@ -6,14 +6,15 @@ import androidx.lifecycle.ViewModel
 import com.example.sideDish.data.source.FoodDetail
 import com.example.sideDish.data.source.FoodRepository
 
-class FoodDetailViewModel( private val repository: FoodRepository , hash: String) : ViewModel() {
+class FoodDetailViewModel(private val repository: FoodRepository, hash: String) : ViewModel() {
     private val _detail = MutableLiveData<FoodDetail>()
     val detail: LiveData<FoodDetail> = _detail
+
+    val orderCount = MutableLiveData<Int>(0)
 
     init {
         getDetail(hash)
     }
-
     fun getDetail(hash: String) {
         _detail.value = repository.getFoodDetail(hash)
     }

--- a/app/src/main/java/com/example/sideDish/ui/productdetail/FoodDetailViewModel.kt
+++ b/app/src/main/java/com/example/sideDish/ui/productdetail/FoodDetailViewModel.kt
@@ -1,0 +1,20 @@
+package com.example.sideDish.ui.productdetail
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.sideDish.data.source.FoodDetail
+import com.example.sideDish.data.source.FoodRepository
+
+class FoodDetailViewModel( private val repository: FoodRepository , hash: String) : ViewModel() {
+    private val _detail = MutableLiveData<FoodDetail>()
+    val detail: LiveData<FoodDetail> = _detail
+
+    init {
+        getDetail(hash)
+    }
+
+    fun getDetail(hash: String) {
+        _detail.value = repository.getFoodDetail(hash)
+    }
+}

--- a/app/src/main/java/com/example/sideDish/ui/productdetail/ProductDetailFragment.kt
+++ b/app/src/main/java/com/example/sideDish/ui/productdetail/ProductDetailFragment.kt
@@ -44,11 +44,14 @@ class ProductDetailFragment : Fragment() {
 
         binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
-                super.onPageSelected(position)
                 // 추후 수정 필요
                 binding.textViewImageIndex.text = "${position + 1}/${dummyList.size}"
             }
         })
         return binding.root
+    }
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt("lastFragment" ,1)
     }
 }

--- a/app/src/main/java/com/example/sideDish/ui/productdetail/ProductDetailFragment.kt
+++ b/app/src/main/java/com/example/sideDish/ui/productdetail/ProductDetailFragment.kt
@@ -1,7 +1,9 @@
 package com.example.sideDish.ui.productdetail
 
+import android.annotation.SuppressLint
 import android.graphics.Paint
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,10 +20,12 @@ import com.example.sideDish.common.ViewModelFactory
 import com.example.sideDish.data.Item
 import com.example.sideDish.data.source.FoodRepository
 import com.example.sideDish.databinding.FragmentProductDetailBinding
+import java.text.DecimalFormat
 
 class ProductDetailFragment : Fragment() {
     private lateinit var binding: FragmentProductDetailBinding
     lateinit var viewModel: FoodDetailViewModel
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -33,6 +37,7 @@ class ProductDetailFragment : Fragment() {
         binding =
             DataBindingUtil.inflate(inflater, R.layout.fragment_product_detail, container, false)
 
+        binding.viewModel = viewModel
         //dummy
         binding.foodInfo = Item.FoodInfo(
             "초계국수_쿠킹박스",
@@ -45,6 +50,12 @@ class ProductDetailFragment : Fragment() {
             "11,800원",
             "초계국수_쿠킹박스"
         )
+
+        viewModel.orderCount.observe(viewLifecycleOwner) {
+            binding.stepper.value.text = it.toString()
+            binding.textViewTotalCostFix.text =
+                "${DecimalFormat("#,###").format(it * (viewModel.detail.value?.discountedPrice ?: 0))}${resources.getString(R.string.money_unit)}"
+        }
 
         viewModel.detail.observe(viewLifecycleOwner) {
             binding.viewPager.adapter = ImageSliderAdapter(it.thumbImageUrls)

--- a/app/src/main/java/com/example/sideDish/ui/productdetail/ProductDetailFragment.kt
+++ b/app/src/main/java/com/example/sideDish/ui/productdetail/ProductDetailFragment.kt
@@ -8,17 +8,28 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.viewpager2.widget.ViewPager2
 import com.example.sideDish.R
+import com.example.sideDish.common.ViewModelFactory
 import com.example.sideDish.data.Item
+import com.example.sideDish.data.source.FoodRepository
 import com.example.sideDish.databinding.FragmentProductDetailBinding
 
 class ProductDetailFragment : Fragment() {
     private lateinit var binding: FragmentProductDetailBinding
+    lateinit var viewModel: FoodDetailViewModel
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+
+        viewModel = ViewModelProvider(this, ViewModelFactory(FoodRepository(), "hash")).get(
+            FoodDetailViewModel::class.java
+        )
         binding =
             DataBindingUtil.inflate(inflater, R.layout.fragment_product_detail, container, false)
 
@@ -34,24 +45,25 @@ class ProductDetailFragment : Fragment() {
             "11,800원",
             "초계국수_쿠킹박스"
         )
-        val dummyList = listOf<String>(
-            "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
-            "http://public.codesquad.kr/jk/storeapp/data/side/17_ZIP_P_6014_T.jpg",
-            "http://public.codesquad.kr/jk/storeapp/data/side/48_ZIP_P_5008_T.jpg",
-        )
-        binding.viewPager.adapter = ImageSliderAdapter(dummyList)
+
+        viewModel.detail.observe(viewLifecycleOwner) {
+            binding.viewPager.adapter = ImageSliderAdapter(it.thumbImageUrls)
+            binding.detail = it
+        }
         binding.viewPager.orientation = ViewPager2.ORIENTATION_HORIZONTAL
 
         binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
-                // 추후 수정 필요
-                binding.textViewImageIndex.text = "${position + 1}/${dummyList.size}"
+                // 추후 수정 필요 data binding 으로 옮기자
+                binding.textViewImageIndex.text =
+                    "${position + 1}/${viewModel.detail.value?.thumbImageUrls?.size}"
             }
         })
         return binding.root
     }
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putInt("lastFragment" ,1)
+        outState.putInt("lastFragment", 1)
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container"
+        android:name="com.example.sideDish.ui.foodlist.FoodListFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_product_detail.xml
+++ b/app/src/main/res/layout/fragment_product_detail.xml
@@ -22,21 +22,21 @@
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0">
 
-            <LinearLayout
-                android:id="@+id/constraint_layout_primary_detail"
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintTop_toBottomOf="@id/constraint_layout_view_pager">
+                android:layout_height="match_parent">
 
                 <!-- 높이 360 고정 값 추후 수정필요 -->
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/constraint_layout_view_pager"
                     android:layout_width="match_parent"
-                    android:layout_height="360dp">
+                    android:layout_height="360dp"
+                    app:layout_constraintTop_toTopOf="parent">
 
                     <androidx.viewpager2.widget.ViewPager2
                         android:id="@+id/view_pager"
@@ -60,223 +60,240 @@
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/text_view_detail_title"
+                    style="@style/TextLarge.Bold"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_margin="16dp"
                     android:layout_marginTop="24dp"
-                    app:layout_constraintTop_toBottomOf="@id/constraint_layout_view_pager">
+                    android:text="@{foodInfo.title}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/constraint_layout_view_pager" />
 
-                    <TextView
-                        android:id="@+id/text_view_detail_title"
-                        style="@style/TextLarge.Bold"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@{foodInfo.title}"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <TextView
-                        android:id="@+id/text_view_detail_body"
-                        style="@style/TextMedium"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@{foodInfo.description}"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/text_view_detail_title" />
-
-                    <LinearLayout
-                        android:id="@+id/linear_layout_price"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        app:layout_constraintTop_toBottomOf="@id/text_view_detail_body">
-
-                        <TextView
-                            android:id="@+id/text_view_discounted_price"
-                            style="@style/TextMedium.Bold"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@{foodInfo.SPrice}"/>
-
-                        <TextView
-                            android:id="@+id/text_view_origin_price"
-                            style="@style/TextSmall"
-
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="10dp"
-                            android:text="@{Html.fromHtml(String.format(@string/original_price, foodInfo.NPrice))}" />
-                    </LinearLayout>
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <LinearLayout
-                    android:id="@+id/linear_layout_event"
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/text_view_detail_body"
+                    style="@style/TextMedium"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:padding="10dp"
-                    app:layout_constraintTop_toBottomOf="@+id/constraint_layout_primary_detail">
+                    android:layout_margin="16dp"
+                    android:layout_marginTop="24dp"
+                    android:text="@{foodInfo.description}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_detail_title" />
 
-                    <TextView
-                        android:id="@+id/text_view_event_event"
-                        style="@style/TextSmall.Primary"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:background="@drawable/curve_corner_light_purple"
-                        android:text="@string/event_price" />
 
-                    <TextView
-                        android:id="@+id/text_view_event_limit"
-                        style="@style/TextSmall.white"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="10dp"
-                        android:background="@drawable/curve_corner_purple"
-                        android:text="@string/limited_price" />
-                </LinearLayout>
+                <TextView
+                    android:id="@+id/text_view_discounted_price"
+                    style="@style/TextMedium.Bold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:text="@{foodInfo.SPrice}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_detail_body" />
+
+                <TextView
+                    android:id="@+id/text_view_origin_price"
+                    style="@style/TextSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:text="@{Html.fromHtml(String.format(@string/original_price, foodInfo.NPrice))}"
+                    app:layout_constraintStart_toEndOf="@id/text_view_discounted_price"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_detail_body" />
+
+
+                <TextView
+                    android:id="@+id/text_view_event_event"
+                    style="@style/TextSmall.Primary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="24dp"
+                    android:background="@drawable/curve_corner_light_purple"
+                    android:text="@string/event_price"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/text_view_origin_price" />
+
+                <TextView
+                    android:id="@+id/text_view_event_limit"
+                    style="@style/TextSmall.white"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginTop="24dp"
+                    android:background="@drawable/curve_corner_purple"
+                    android:text="@string/limited_price"
+                    app:layout_constraintStart_toEndOf="@id/text_view_event_event"
+                    app:layout_constraintTop_toBottomOf="@+id/text_view_origin_price" />
+
 
                 <View
+                    android:id="@+id/view1"
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     android:layout_marginTop="30dp"
                     android:layout_marginBottom="24dp"
                     android:background="#F5F5F7"
-                    app:layout_constraintTop_toBottomOf="@id/linear_layout_event" />
+                    app:layout_constraintTop_toBottomOf="@id/text_view_event_event" />
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+
+                <TextView
+                    android:id="@+id/text_view_accumulate_fix"
+                    style="@style/TextSmall.gray"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
-                    android:layout_marginBottom="16dp">
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="16dp"
+                    android:text="@string/reserves"
+                    app:layout_constraintEnd_toStartOf="@id/text_view_accumulate"
+                    app:layout_constraintHorizontal_weight="3"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/view1" />
 
-                    <TextView
-                        style="@style/TextSmall.gray"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="2"
-                        android:text="@string/reserves" />
-
-                    <TextView
-                        style="@style/TextSmall.gray"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="8"
-                        android:text="temp:126원" />
-
-                </LinearLayout>
-
-
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/text_view_info_deliver_fix"
+                    style="@style/TextSmall.gray"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
-                    android:layout_marginBottom="16dp">
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="16dp"
+                    android:text="@string/delivery_info"
+                    app:layout_constraintEnd_toStartOf="@id/text_view_info_deliver"
+                    app:layout_constraintHorizontal_weight="3"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_accumulate" />
 
-                    <TextView
-                        style="@style/TextSmall.gray"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="2"
-                        android:text="@string/delivery_info" />
+                <TextView
+                    android:id="@+id/text_view_accumulate"
+                    style="@style/TextSmall.gray"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="16dp"
+                    android:layout_weight="8"
+                    android:text="temp:126원"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_weight="8"
+                    app:layout_constraintStart_toEndOf="@id/text_view_accumulate_fix"
+                    app:layout_constraintTop_toBottomOf="@id/view1" />
 
-                    <TextView
-                        style="@style/TextSmall.gray"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="8"
-                        android:text="temp:서울 경기 새벽 배송, 전국 택배 배송" />
 
-                </LinearLayout>
+                <TextView
+                    android:id="@+id/text_view_info_deliver"
+                    style="@style/TextSmall.gray"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="16dp"
+                    android:text="temp:서울 경기 새벽 배송, 전국 택배 배송"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_weight="8"
+                    app:layout_constraintStart_toEndOf="@id/text_view_info_deliver_fix"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_accumulate" />
 
-                <LinearLayout
-                    android:id="@+id/linear_layout_delivery_price"
-                    android:layout_width="match_parent"
+
+                <TextView
+                    android:id="@+id/text_view_delivery_cost_fix"
+                    style="@style/TextSmall.gray"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
-                    android:layout_marginBottom="24dp">
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="24dp"
+                    android:text="@string/delivery_price"
+                    app:layout_constraintEnd_toStartOf="@id/text_view_delivery_cost"
+                    app:layout_constraintHorizontal_weight="3"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_info_deliver" />
 
-                    <TextView
-                        style="@style/TextSmall.gray"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="2"
-                        android:text="@string/delivery_price" />
+                <TextView
+                    android:id="@+id/text_view_delivery_cost"
+                    style="@style/TextSmall.gray"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="24dp"
+                    android:text="temp:2500원(40,000 이상 구매시 무료)"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_weight="8"
+                    app:layout_constraintStart_toEndOf="@id/text_view_delivery_cost_fix"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_info_deliver" />
 
-                    <TextView
-                        style="@style/TextSmall.gray"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="8"
-                        android:text="temp:2500원(40,000 이상 구매시 무료)" />
-
-
-                </LinearLayout>
 
                 <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginBottom="34dp"
-                    android:background="#F5F5F7"
-                    app:layout_constraintTop_toBottomOf="@id/linear_layout_delivery_price" />
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="16dp"
-                    android:paddingRight="16dp">
-
-                    <TextView
-                        style="@style/TextSmall.gray"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/count"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <com.example.sideDish.ui.Stepper
-
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <View
+                    android:id="@+id/view2"
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     android:layout_marginTop="34dp"
                     android:layout_marginBottom="34dp"
                     android:background="#F5F5F7"
-                    app:layout_constraintTop_toBottomOf="@id/linear_layout_delivery_price" />
+                    app:layout_constraintTop_toBottomOf="@id/text_view_delivery_cost" />
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
+
+                <TextView
+                    android:id="@+id/text_view_count_fix"
+                    style="@style/TextSmall.gray"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingEnd="16dp">
+                    android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
+                    android:text="@string/count"
+                    app:layout_constraintBottom_toTopOf="@id/view3"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/view2" />
 
-                    <TextView
-                        android:id="@+id/text_view_total_price"
-                        style="@style/TextLarge.Bold"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="temp:12,640원"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
+                <com.example.sideDish.ui.Stepper
+                    android:layout_marginTop="16dp"
+                    android:id="@+id/stepper"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/view2" />
 
-                    <TextView
-                        style="@style/TextMedium"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="24dp"
-                        android:text="@string/total_price"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toStartOf="@id/text_view_total_price"
-                        app:layout_constraintTop_toTopOf="parent" />
-                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <View
+                    android:id="@+id/view3"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="34dp"
+                    android:layout_marginBottom="34dp"
+                    android:background="#F5F5F7"
+                    app:layout_constraintTop_toBottomOf="@id/stepper" />
+
+
+                <TextView
+                    android:id="@+id/text_view_total_cost_fix"
+                    style="@style/TextLarge.Bold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="temp:12,640원"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/view3"
+                    app:layout_constraintBottom_toTopOf="@id/button_order"/>
+
+
+                <TextView
+                    android:layout_marginTop="34dp"
+                    android:id="@+id/text_view_total_cost"
+                    style="@style/TextMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="24dp"
+                    android:paddingEnd="16dp"
+                    android:text="@string/total_price"
+                    app:layout_constraintEnd_toStartOf="@id/text_view_total_cost_fix"
+                    app:layout_constraintTop_toBottomOf="@+id/view3"
+
+                    />
 
                 <Button
                     android:id="@+id/button_order"
@@ -284,9 +301,10 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:padding="16dp"
-                    android:text="@string/order" />
+                    android:text="@string/order"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_total_cost" />
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </ScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_product_detail.xml
+++ b/app/src/main/res/layout/fragment_product_detail.xml
@@ -8,6 +8,14 @@
         <import type="android.text.Html" />
 
         <variable
+            name="viewModel"
+            type="com.example.sideDish.ui.productdetail.FoodDetailViewModel" />
+
+        <variable
+            name="count"
+            type="Integer" />
+
+        <variable
             name="detail"
             type="com.example.sideDish.data.source.FoodDetail" />
 
@@ -255,6 +263,8 @@
 
                 <com.example.sideDish.ui.Stepper
                     android:id="@+id/stepper"
+                    android:count="@{viewModel.orderCount}"
+                    viewModel="@{viewModel}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
@@ -309,22 +319,22 @@
                     app:layout_constraintTop_toBottomOf="@id/text_view_total_cost" />
 
                 <ImageView
-                    image="@{detail.detailImageUrls.get(0)}"
                     android:id="@+id/image_view_detail1"
+                    image="@{detail.detailImageUrls.get(0)}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toBottomOf="@id/button_order" />
 
                 <ImageView
-                    image="@{detail.detailImageUrls.get(1)}"
                     android:id="@+id/image_view_detail2"
+                    image="@{detail.detailImageUrls.get(1)}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toBottomOf="@id/image_view_detail1" />
 
                 <ImageView
-                    image="@{detail.detailImageUrls.get(2)}"
                     android:id="@+id/image_view_detail3"
+                    image="@{detail.detailImageUrls.get(2)}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toBottomOf="@id/image_view_detail2" />

--- a/app/src/main/res/layout/fragment_product_detail.xml
+++ b/app/src/main/res/layout/fragment_product_detail.xml
@@ -250,10 +250,10 @@
                     app:layout_constraintTop_toBottomOf="@+id/view2" />
 
                 <com.example.sideDish.ui.Stepper
-                    android:layout_marginTop="16dp"
                     android:id="@+id/stepper"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
                     android:paddingLeft="16dp"
                     android:paddingRight="16dp"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -276,17 +276,17 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="temp:12,640원"
+                    app:layout_constraintBottom_toTopOf="@id/button_order"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/view3"
-                    app:layout_constraintBottom_toTopOf="@id/button_order"/>
+                    app:layout_constraintTop_toBottomOf="@+id/view3" />
 
 
                 <TextView
-                    android:layout_marginTop="34dp"
                     android:id="@+id/text_view_total_cost"
                     style="@style/TextMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="34dp"
                     android:layout_marginEnd="24dp"
                     android:paddingEnd="16dp"
                     android:text="@string/total_price"
@@ -303,6 +303,24 @@
                     android:padding="16dp"
                     android:text="@string/order"
                     app:layout_constraintTop_toBottomOf="@id/text_view_total_cost" />
+
+                <ImageView
+                    android:id="@+id/image_view_detail1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/button_order" />
+
+                <ImageView
+                    android:id="@+id/image_view_detail2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/image_view_detail1" />
+
+                <ImageView
+                    android:id="@+id/image_view_detail3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/image_view_detail2" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_product_detail.xml
+++ b/app/src/main/res/layout/fragment_product_detail.xml
@@ -8,6 +8,10 @@
         <import type="android.text.Html" />
 
         <variable
+            name="detail"
+            type="com.example.sideDish.data.source.FoodDetail" />
+
+        <variable
             name="foodInfo"
             type="com.example.sideDish.data.Item.FoodInfo" />
     </data>
@@ -176,7 +180,7 @@
                     android:layout_marginEnd="16dp"
                     android:layout_marginBottom="16dp"
                     android:layout_weight="8"
-                    android:text="temp:126원"
+                    android:text="@{detail.point}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_weight="8"
                     app:layout_constraintStart_toEndOf="@id/text_view_accumulate_fix"
@@ -191,7 +195,7 @@
                     android:layout_marginTop="16dp"
                     android:layout_marginEnd="16dp"
                     android:layout_marginBottom="16dp"
-                    android:text="temp:서울 경기 새벽 배송, 전국 택배 배송"
+                    android:text="@{detail.deliveryInfo}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_weight="8"
                     app:layout_constraintStart_toEndOf="@id/text_view_info_deliver_fix"
@@ -220,7 +224,7 @@
                     android:layout_marginTop="16dp"
                     android:layout_marginEnd="16dp"
                     android:layout_marginBottom="24dp"
-                    android:text="temp:2500원(40,000 이상 구매시 무료)"
+                    android:text="@{detail.deliveryFee}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_weight="8"
                     app:layout_constraintStart_toEndOf="@id/text_view_delivery_cost_fix"
@@ -275,7 +279,7 @@
                     style="@style/TextLarge.Bold"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="temp:12,640원"
+                    android:text="temp: 1000원"
                     app:layout_constraintBottom_toTopOf="@id/button_order"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/view3" />
@@ -305,18 +309,21 @@
                     app:layout_constraintTop_toBottomOf="@id/text_view_total_cost" />
 
                 <ImageView
+                    image="@{detail.detailImageUrls.get(0)}"
                     android:id="@+id/image_view_detail1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toBottomOf="@id/button_order" />
 
                 <ImageView
+                    image="@{detail.detailImageUrls.get(1)}"
                     android:id="@+id/image_view_detail2"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toBottomOf="@id/image_view_detail1" />
 
                 <ImageView
+                    image="@{detail.detailImageUrls.get(2)}"
                     android:id="@+id/image_view_detail3"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/section.xml
+++ b/app/src/main/res/layout/section.xml
@@ -3,6 +3,18 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+        
+        <variable
+            name="section"
+            type="com.example.sideDish.data.Item.Section" />
+        
+        <variable
+            name="viewmodel"
+            type="com.example.sideDish.ui.foodlist.FoodListViewModel" />
+        
+    </data>
+    
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">

--- a/app/src/main/res/layout/stepper.xml
+++ b/app/src/main/res/layout/stepper.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
@@ -13,7 +14,9 @@
         android:background="@drawable/elevate_circle"
         android:elevation="5dp"
         android:padding="10dp"
-        android:src="@drawable/ic_baseline_minus_24" />
+        android:src="@drawable/ic_baseline_minus_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/text_view_stepper_value"
@@ -24,7 +27,10 @@
         android:paddingTop="3dp"
         android:paddingRight="15dp"
         android:paddingBottom="3dp"
-        android:text="100" />
+        android:text="100"
+        app:layout_constraintEnd_toStartOf="@id/button_stepper_plus"
+        app:layout_constraintStart_toEndOf="@id/button_stepper_minus"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageButton
         android:id="@+id/button_stepper_plus"
@@ -33,5 +39,8 @@
         android:background="@drawable/elevate_circle"
         android:elevation="5dp"
         android:padding="10dp"
-        android:src="@drawable/ic_add" />
-</LinearLayout>
+        android:src="@drawable/ic_add"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/text_view_stepper_value"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="count">수량</string>
     <string name="total_price">총 주문 금액</string>
     <string name="order">주문하기</string>
+
+    <string name="money_unit">원</string>
 </resources>


### PR DESCRIPTION
안녕하세요 ! 저번 1차 PR에서 시간이 촉박해서 소개를 못한 점 죄송합니다.
저희는 jay & wooki 팀입니다. 2주동안 잘 부탁드립니다 !

---
## 결과물

https://user-images.githubusercontent.com/29175138/164601608-9fde3af2-93a8-41e1-86c3-adba7a243105.mov

## 작업사항
- 피드백 반영
  - 음식 리스트의 리사이클러 뷰 수정 (ListAdapter 및 DiffUtil 이용)
  - Stepper Layout을 ConstraintLayout 으로 변경
  - error 함수 사용 및 Food Category enum 클래스 수정
  - DetailFragment Layout 중첩되지 않도록 수정

- 상세 화면 수정
  - Stepper 이벤트 처리
    - 수량 증감 및 총 주문 금액 변화
  - ViewModel 추가
  - Detail API 수정 내용 반영

## 질문사항
- 섹션 클릭시 해당 섹션에 대한 데이터만 변경되어야 하는데 다른 섹션의 데이터까지 변경됩니다.. [SectionViewHoder](https://github.com/codesquad-members-2022/sidedish/compare/team-29...banjjak2:release/2.0#diff-409758013ba83f44aecc26fa181663fcd9a3ff7a69b262bc2da70fbe07748c05R21)에서 setOnClickListener를 등록 및 Text를 써줬는데 왜 다른 섹션까지 같이 보여지게 되는지 궁금합니다.
- 커스텀뷰(Stepper)와 뷰모델간의 two-way binding 을 위해서 커스텀뷰를 포함하고 있는 프레그먼트 xml에 viewmodel 을 변수로 넘겨 커스텀뷰 내부에서 viewModel 을 받아 사용했는데 해당 구현에 문제가 있는지 알고싶습니다.


