### PR TITLE
[Team-03][BE][루이&쿠킴] - 배포 자동화 스크립트, GitHub OAuth를 이용한 로그인 기능 구현

### DIFF
--- a/BE/src/main/java/sidedish/com/config/GitHubOAuthUtils.java
+++ b/BE/src/main/java/sidedish/com/config/GitHubOAuthUtils.java
@@ -1,0 +1,23 @@
+package sidedish.com.config;
+
+public class GitHubOAuthUtils {
+
+	public static final String DNS_NAME;
+	public static final String CALLBACK_URL;
+	public static final String CLIENT_ID;
+	public static final String CLIENT_SECRET;
+	public static final String LOCATION;
+	public static final String ACCESSTOKEN_API_URL;
+	public static final String USER_API_URL;
+
+	static {
+		DNS_NAME = System.getenv("DNS_NAME");
+		CALLBACK_URL = DNS_NAME + "/api/login/callback";
+		CLIENT_ID = System.getenv("GITHUB_CLIENT_ID");
+		CLIENT_SECRET = System.getenv("GITHUB_CLIENT_SECRET");
+		LOCATION = "https://github.com/login/oauth/authorize?client_id=" + CLIENT_ID +
+			"&redirect_uri=" + CALLBACK_URL;
+		ACCESSTOKEN_API_URL = "https://github.com/login/oauth/access_token";
+		USER_API_URL = "https://api.github.com/user";
+	}
+}

--- a/BE/src/main/java/sidedish/com/config/WebConfig.java
+++ b/BE/src/main/java/sidedish/com/config/WebConfig.java
@@ -3,9 +3,13 @@ package sidedish.com.config;
 import java.util.Map;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import sidedish.com.interceptor.LoginInterceptor;
 
 @Configuration
+@EnableWebMvc
 public class WebConfig implements WebMvcConfigurer {
 
 	@Override
@@ -17,5 +21,11 @@ public class WebConfig implements WebMvcConfigurer {
 
 		registry.addMapping("/**")
 			.allowedOrigins(localIp, awsIp, dnsName);
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new LoginInterceptor())
+			.addPathPatterns("/api/products/*/order");
 	}
 }

--- a/BE/src/main/java/sidedish/com/controller/DomainDtoMapper.java
+++ b/BE/src/main/java/sidedish/com/controller/DomainDtoMapper.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Component;
 import sidedish.com.controller.model.OrderSaveResponse;
 import sidedish.com.controller.model.ProductDetailTypeResponse;
 import sidedish.com.controller.model.ProductBasicTypeResponse;
+import sidedish.com.controller.model.UserResponse;
 import sidedish.com.domain.Product;
+import sidedish.com.domain.User;
 import sidedish.com.repository.entity.OrderEntity;
 
 @Component
@@ -52,4 +54,7 @@ public class DomainDtoMapper {
 		return new OrderSaveResponse(orderEntity.getId());
 	}
 
+	public UserResponse toUserResponseFromUser(User user) {
+		return new UserResponse(user.getId(), user.getUserName(), user.getAvatarImageURL());
+	}
 }

--- a/BE/src/main/java/sidedish/com/controller/LoginController.java
+++ b/BE/src/main/java/sidedish/com/controller/LoginController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import sidedish.com.controller.model.UserResponse;
 import sidedish.com.service.LoginService;
 
 @RequiredArgsConstructor
@@ -34,8 +35,13 @@ public class LoginController {
 
 	@GetMapping("/login/callback")
 	public ResponseEntity<Object> login(@RequestParam String code, HttpSession session) {
-		Long userId = loginService.login(code);
-		session.setAttribute("userId", userId);
+		UserResponse user = loginService.login(code);
+		session.setAttribute("userId", user.getId());
+
+		/**
+		 * TODO : 프론트 협의해야함
+		 */
+//		return user;
 		return ResponseEntity.status(HttpStatus.SEE_OTHER)
 			.location(URI.create("http://localhost:8080"))
 			.build();

--- a/BE/src/main/java/sidedish/com/controller/LoginController.java
+++ b/BE/src/main/java/sidedish/com/controller/LoginController.java
@@ -1,0 +1,27 @@
+package sidedish.com.controller;
+
+import java.net.URI;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class LoginController {
+
+	public static final String callbackUrl = "http://localhost:8080/api/login/callback";
+	private String clientId = "9819a665d5d8256d5ad6";
+	private String clientSecret = "684aa9107cd2d757809f7fb642bab01c041a06aa";
+
+	@GetMapping("/login")
+	public ResponseEntity<Object> loginPage() {
+		String location = "https://github.com/login/oauth/authorize?client_id=" + clientId +
+			"&redirect_uri=" + callbackUrl;
+
+		return ResponseEntity.status(HttpStatus.SEE_OTHER)
+			.location(URI.create(location))
+			.build();
+	}
+}

--- a/BE/src/main/java/sidedish/com/controller/LoginController.java
+++ b/BE/src/main/java/sidedish/com/controller/LoginController.java
@@ -1,6 +1,7 @@
 package sidedish.com.controller;
 
 import java.net.URI;
+import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +33,11 @@ public class LoginController {
 	}
 
 	@GetMapping("/login/callback")
-	public void login(@RequestParam String code) {
-		loginService.login(code);
+	public ResponseEntity<Object> login(@RequestParam String code, HttpSession session) {
+		Long userId = loginService.login(code);
+		session.setAttribute("userId", userId);
+		return ResponseEntity.status(HttpStatus.SEE_OTHER)
+			.location(URI.create("http://localhost:8080"))
+			.build();
 	}
 }

--- a/BE/src/main/java/sidedish/com/controller/LoginController.java
+++ b/BE/src/main/java/sidedish/com/controller/LoginController.java
@@ -46,4 +46,12 @@ public class LoginController {
 			.location(URI.create("http://localhost:8080"))
 			.build();
 	}
+
+	@GetMapping("/logout")
+	public ResponseEntity<Object> logout(HttpSession session) {
+		session.invalidate();
+		return ResponseEntity.status(HttpStatus.SEE_OTHER)
+			.location(URI.create("http://localhost:8080"))
+			.build();
+	}
 }

--- a/BE/src/main/java/sidedish/com/controller/LoginController.java
+++ b/BE/src/main/java/sidedish/com/controller/LoginController.java
@@ -1,15 +1,21 @@
 package sidedish.com.controller;
 
 import java.net.URI;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import sidedish.com.service.LoginService;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api")
 public class LoginController {
+
+	private final LoginService loginService;
 
 	public static final String callbackUrl = "http://localhost:8080/api/login/callback";
 	private String clientId = "9819a665d5d8256d5ad6";
@@ -23,5 +29,10 @@ public class LoginController {
 		return ResponseEntity.status(HttpStatus.SEE_OTHER)
 			.location(URI.create(location))
 			.build();
+	}
+
+	@GetMapping("/login/callback")
+	public void login(@RequestParam String code) {
+		loginService.login(code);
 	}
 }

--- a/BE/src/main/java/sidedish/com/controller/LoginController.java
+++ b/BE/src/main/java/sidedish/com/controller/LoginController.java
@@ -1,5 +1,7 @@
 package sidedish.com.controller;
 
+import static sidedish.com.config.GitHubOAuthUtils.*;
+
 import java.net.URI;
 import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -19,17 +21,10 @@ public class LoginController {
 
 	private final LoginService loginService;
 
-	public static final String callbackUrl = "http://localhost:8080/api/login/callback";
-	private String clientId = "9819a665d5d8256d5ad6";
-	private String clientSecret = "684aa9107cd2d757809f7fb642bab01c041a06aa";
-
 	@GetMapping("/login")
 	public ResponseEntity<Object> loginPage() {
-		String location = "https://github.com/login/oauth/authorize?client_id=" + clientId +
-			"&redirect_uri=" + callbackUrl;
-
 		return ResponseEntity.status(HttpStatus.SEE_OTHER)
-			.location(URI.create(location))
+			.location(URI.create(LOCATION))
 			.build();
 	}
 
@@ -43,7 +38,7 @@ public class LoginController {
 		 */
 //		return user;
 		return ResponseEntity.status(HttpStatus.SEE_OTHER)
-			.location(URI.create("http://localhost:8080"))
+			.location(URI.create(DNS_NAME))
 			.build();
 	}
 
@@ -51,7 +46,7 @@ public class LoginController {
 	public ResponseEntity<Object> logout(HttpSession session) {
 		session.invalidate();
 		return ResponseEntity.status(HttpStatus.SEE_OTHER)
-			.location(URI.create("http://localhost:8080"))
+			.location(URI.create(DNS_NAME))
 			.build();
 	}
 }

--- a/BE/src/main/java/sidedish/com/controller/model/GitHubAccessToken.java
+++ b/BE/src/main/java/sidedish/com/controller/model/GitHubAccessToken.java
@@ -1,0 +1,19 @@
+package sidedish.com.controller.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class GitHubAccessToken {
+
+	@JsonProperty("access_token")
+	private String accessToken;
+
+	@JsonProperty("token_type")
+	private String tokenType;
+
+	@JsonProperty("scope")
+	private String scope;
+}

--- a/BE/src/main/java/sidedish/com/controller/model/UserResponse.java
+++ b/BE/src/main/java/sidedish/com/controller/model/UserResponse.java
@@ -1,0 +1,16 @@
+package sidedish.com.controller.model;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResponse {
+
+	@JsonIgnore
+	private Long id;
+	private String userName;
+	private String avatarImageURL;
+}

--- a/BE/src/main/java/sidedish/com/domain/GitHubAccessToken.java
+++ b/BE/src/main/java/sidedish/com/domain/GitHubAccessToken.java
@@ -1,4 +1,4 @@
-package sidedish.com.controller.model;
+package sidedish.com.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/BE/src/main/java/sidedish/com/domain/User.java
+++ b/BE/src/main/java/sidedish/com/domain/User.java
@@ -1,0 +1,20 @@
+package sidedish.com.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class User {
+
+	@JsonProperty("login")
+	private String userName;
+
+	@JsonProperty("avatar_url")
+	private String avatarImageURL;
+
+	@JsonProperty("email")
+	private String email;
+
+}

--- a/BE/src/main/java/sidedish/com/domain/User.java
+++ b/BE/src/main/java/sidedish/com/domain/User.java
@@ -1,12 +1,19 @@
 package sidedish.com.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Embedded;
 
 @Getter
 @ToString
 public class User {
+
+	@Id
+	@JsonIgnore
+	private Long id;
 
 	@JsonProperty("login")
 	private String userName;
@@ -17,4 +24,10 @@ public class User {
 	@JsonProperty("email")
 	private String email;
 
+	@Embedded.Nullable
+	private GitHubAccessToken accessToken;
+
+	public void setAccessToken(GitHubAccessToken accessToken) {
+		this.accessToken = accessToken;
+	}
 }

--- a/BE/src/main/java/sidedish/com/interceptor/LoginInterceptor.java
+++ b/BE/src/main/java/sidedish/com/interceptor/LoginInterceptor.java
@@ -1,0 +1,28 @@
+package sidedish.com.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class LoginInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+		Object handler) throws Exception {
+		if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+			return true;
+		}
+
+		HttpSession session = request.getSession();
+		Long userId = (Long) session.getAttribute("userId");
+		if (userId == null) {
+			response.sendRedirect("http://localhost:8080");
+			return false;
+		}
+		return true;
+	}
+}

--- a/BE/src/main/java/sidedish/com/repository/UserRepository.java
+++ b/BE/src/main/java/sidedish/com/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package sidedish.com.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import sidedish.com.domain.User;
+
+public interface UserRepository extends CrudRepository<User, Long> {
+
+}

--- a/BE/src/main/java/sidedish/com/service/LoginService.java
+++ b/BE/src/main/java/sidedish/com/service/LoginService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import sidedish.com.controller.DomainDtoMapper;
+import sidedish.com.controller.model.UserResponse;
 import sidedish.com.domain.GitHubAccessToken;
 import sidedish.com.domain.User;
 import sidedish.com.repository.UserRepository;
@@ -17,18 +19,18 @@ import sidedish.com.repository.UserRepository;
 @RequiredArgsConstructor
 @Service
 public class LoginService {
+
+	private final DomainDtoMapper domainDtoMapper;
 	private final UserRepository userRepository;
 	private String clientId = "9819a665d5d8256d5ad6";
 	private String clientSecret = "684aa9107cd2d757809f7fb642bab01c041a06aa";
 	private String accessTokenApiUrl = "https://github.com/login/oauth/access_token";
 
-	public Long login(String code) {
+	public UserResponse login(String code) {
 		GitHubAccessToken accessToken = requestAccessToken(code);
 		User user = requestUser(accessToken);
-		User savedUser = userRepository.save(user);
-		User user1 = userRepository.findById(savedUser.getId()).orElseThrow();
-		System.out.println("user1 = " + user1);
-		return savedUser.getId();
+		User saveUser = userRepository.save(user);
+		return domainDtoMapper.toUserResponseFromUser(saveUser);
 	}
 
 	private User requestUser(GitHubAccessToken accessToken) {

--- a/BE/src/main/java/sidedish/com/service/LoginService.java
+++ b/BE/src/main/java/sidedish/com/service/LoginService.java
@@ -1,0 +1,34 @@
+package sidedish.com.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import sidedish.com.controller.model.GitHubAccessToken;
+
+@Service
+public class LoginService {
+	private String clientId = "9819a665d5d8256d5ad6";
+	private String clientSecret = "684aa9107cd2d757809f7fb642bab01c041a06aa";
+	private String accessTokenApiUrl = "https://github.com/login/oauth/access_token";
+
+	public void login(String code) {
+		GitHubAccessToken accessToken = requestAccessToken(code);
+	}
+
+	public GitHubAccessToken requestAccessToken(String code) {
+		MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+		headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("code", code);
+		params.add("client_id", clientId);
+		params.add("client_secret", clientSecret);
+
+		return new RestTemplate()
+			.postForEntity(accessTokenApiUrl, new HttpEntity<>(params, headers),
+				GitHubAccessToken.class).getBody();
+	}
+}

--- a/BE/src/main/java/sidedish/com/service/LoginService.java
+++ b/BE/src/main/java/sidedish/com/service/LoginService.java
@@ -1,5 +1,7 @@
 package sidedish.com.service;
 
+import static sidedish.com.config.GitHubOAuthUtils.*;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
@@ -22,9 +24,6 @@ public class LoginService {
 
 	private final DomainDtoMapper domainDtoMapper;
 	private final UserRepository userRepository;
-	private String clientId = "9819a665d5d8256d5ad6";
-	private String clientSecret = "684aa9107cd2d757809f7fb642bab01c041a06aa";
-	private String accessTokenApiUrl = "https://github.com/login/oauth/access_token";
 
 	public UserResponse login(String code) {
 		GitHubAccessToken accessToken = requestAccessToken(code);
@@ -39,7 +38,7 @@ public class LoginService {
 		httpHeaders.setBearerAuth(accessToken.getAccessToken());
 
 		User user = new RestTemplate()
-			.exchange("https://api.github.com/user", HttpMethod.GET,
+			.exchange(USER_API_URL, HttpMethod.GET,
 				new HttpEntity<>(httpHeaders), User.class).getBody();
 		user.setAccessToken(accessToken);
 		return user;
@@ -51,11 +50,11 @@ public class LoginService {
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("code", code);
-		params.add("client_id", clientId);
-		params.add("client_secret", clientSecret);
+		params.add("client_id", CLIENT_ID);
+		params.add("client_secret", CLIENT_SECRET);
 
 		return new RestTemplate()
-			.postForEntity(accessTokenApiUrl, new HttpEntity<>(params, headers),
+			.postForEntity(ACCESSTOKEN_API_URL, new HttpEntity<>(params, headers),
 				GitHubAccessToken.class).getBody();
 	}
 }

--- a/BE/src/main/java/sidedish/com/service/LoginService.java
+++ b/BE/src/main/java/sidedish/com/service/LoginService.java
@@ -1,12 +1,16 @@
 package sidedish.com.service;
 
+import java.util.List;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import sidedish.com.controller.model.GitHubAccessToken;
+import sidedish.com.domain.User;
 
 @Service
 public class LoginService {
@@ -16,6 +20,17 @@ public class LoginService {
 
 	public void login(String code) {
 		GitHubAccessToken accessToken = requestAccessToken(code);
+		User user = requestUser(accessToken);
+	}
+
+	private User requestUser(GitHubAccessToken accessToken) {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
+		httpHeaders.setBearerAuth(accessToken.getAccessToken());
+
+		return new RestTemplate()
+			.exchange("https://api.github.com/user", HttpMethod.GET,
+				new HttpEntity<>(httpHeaders), User.class).getBody();
 	}
 
 	public GitHubAccessToken requestAccessToken(String code) {

--- a/BE/src/main/resources/db/schema.sql
+++ b/BE/src/main/resources/db/schema.sql
@@ -60,6 +60,6 @@ create table user
     avatar_image_url text         not null,
     email            varchar(1000),
     access_token     text         not null,
-    token_type       varchar      not null,
-    scope            varchar      not null
+    token_type       varchar(100)      not null,
+    scope            varchar(100)      not null
 );

--- a/BE/src/main/resources/db/schema.sql
+++ b/BE/src/main/resources/db/schema.sql
@@ -56,10 +56,10 @@ create table orders
 create table user
 (
     id               bigint auto_increment primary key,
-    user_name        varchar(100)  not null,
-    avatar_image_url text          not null,
-    email            varchar(1000) not null,
-    access_token     text          not null,
-    token_type       varchar       not null,
-    scope            varchar       not null
+    user_name        varchar(100) not null,
+    avatar_image_url text         not null,
+    email            varchar(1000),
+    access_token     text         not null,
+    token_type       varchar      not null,
+    scope            varchar      not null
 );

--- a/BE/src/main/resources/db/schema.sql
+++ b/BE/src/main/resources/db/schema.sql
@@ -1,3 +1,4 @@
+drop table if exists user;
 drop table if exists orders;
 drop table if exists product_image;
 drop table if exists product;
@@ -36,18 +37,29 @@ create table product
 
 create table product_image
 (
-    id         bigint           auto_increment primary key,
-    product_id bigint           not null,
-    image_url  varchar(1000)    not null,
+    id         bigint auto_increment primary key,
+    product_id bigint        not null,
+    image_url  varchar(1000) not null,
     foreign key (product_id) references product (id)
 );
 
 create table orders
 (
-    id              bigint          auto_increment primary key,
-    product_id      bigint          not null,
-    total_price     bigint          not null,
-    count           bigint          not null,
-    delivery_price  bigint          not null,
+    id             bigint auto_increment primary key,
+    product_id     bigint not null,
+    total_price    bigint not null,
+    count          bigint not null,
+    delivery_price bigint not null,
     foreign key (product_id) references product (id)
+);
+
+create table user
+(
+    id               bigint auto_increment primary key,
+    user_name        varchar(100)  not null,
+    avatar_image_url text          not null,
+    email            varchar(1000) not null,
+    access_token     text          not null,
+    token_type       varchar       not null,
+    scope            varchar       not null
 );

--- a/BE/src/test/resources/testdb/schema.sql
+++ b/BE/src/test/resources/testdb/schema.sql
@@ -1,3 +1,4 @@
+drop table if exists user;
 drop table if exists orders;
 drop table if exists product_image;
 drop table if exists product;
@@ -44,10 +45,21 @@ create table product_image
 
 create table orders
 (
-    id              bigint          auto_increment primary key,
-    product_id      bigint          not null,
-    total_price     bigint          not null,
-    count           bigint          not null,
-    delivery_price  bigint          not null,
+    id             bigint auto_increment primary key,
+    product_id     bigint not null,
+    total_price    bigint not null,
+    count          bigint not null,
+    delivery_price bigint not null,
     foreign key (product_id) references product (id)
+);
+
+create table user
+(
+    id               bigint auto_increment primary key,
+    user_name        varchar(100)  not null,
+    avatar_image_url text          not null,
+    email            varchar(1000) not null,
+    access_token     text          not null,
+    token_type       varchar       not null,
+    scope            varchar       not null
 );

--- a/depoly.sh
+++ b/depoly.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+echo "====== [Depoly] start ======"
+echo "[Depoly] init system env"
+source /etc/profile > /dev/null 2>&1
+
+git fetch
+remote=` git rev-parse origin/team-03`
+present=` git rev-parse team-03`
+
+if [[ $remote == $present ]]; then
+	echo "[Depoly] 현재 최신 버전입니다. 스크립트를 종료합니다."
+	exit 0
+fi
+
+echo "[Depoly] 리포지토리 최신화"
+git merge origin/team-03
+
+echo "====== [FE] 새로운 View react 빌드 ======"
+cd ./FE
+npm install
+npm run build
+cd ../
+echo "====== [FE] 새로운 View react 빌드완료 ======"
+
+
+echo "====== [BE] 이전 서버 종료 ======"
+cd ./BE
+sidedish=` jps | grep com | cut -d' ' -f1`
+kill -9 $sidedish
+
+echo "====== [BE] 새로운 서버 실행 ======"
+bash ./gradlew clean bootjar
+nohup java -jar build/libs/com-0.0.1-SNAPSHOT.jar &
+
+cd ../
+echo "[BE] 완료"
+
+echo "====== [Depoly] Done ======"


### PR DESCRIPTION
안녕하세요 잭! 루이 & 쿠킴입니다 😀
벌써 마지막 PR을 보내는군요 ㅠㅠ
2주 동안 리뷰해 주시느라 고생 많으셨습니다! 
감사합니다 잭 😊

## 주요 구현 사항
- 배포 자동화 스크립트 완성([depoly.sh](https://github.com/codesquad-members-2022/sidedish/pull/185/files#diff-1d72dce49faace478b75e5968ceb3a6ab0bd4ab8aa6ca1df6d6c7f627c497fd7))
  - 리눅스의 `cronrab`을 통해서 일정 시간마다 upstream의 `team-03` 브랜치를 해당 스크립트를 통해 자동으로 배포하려고 했습니다.
  - 하지만 upstream의 `team-03`에는 PR 리뷰를 받아야 하기 때문에 바로 적용하고 싶은 사항을 push하지 못합니다.
  - 이러한 단점 때문에 해당 스크립트는 아직 서버에서는 주기적으로 실행하지 않고 있습니다.
- GitHub OAuth를 이용한 로그인 / 로그아웃 기능 구현
  - User 저장하기 구현
  - GitHub OAuth와 관련된 중요한 정보는 환경 변수로 설정
  - 로그인한 사용자만 주문할 수 있도록 인터셉터 구현
- 주문 시 상품의 재고 수량이 부족하다면 남아있는 재고 수량을 보내주도록 `GlobalExceptionHandler` 구현

## 결과
- [배포 서버 URL](http://www.louie-03.com)

<details>
<summary> 로그인 </summary>
<div markdown="1">


![image](https://user-images.githubusercontent.com/92966772/165878383-13dec788-23bd-4383-a9cf-717d967c51db.png)

![Imgur](https://i.imgur.com/pKMqXin.jpg)

</div>
</details>


