### PR TITLE
[team-32][FE] otter & jinnie 2주차 두 번째 PR review-FE

### DIFF
--- a/fe/src/App.js
+++ b/fe/src/App.js
@@ -5,24 +5,38 @@ import Tab from "./component/Tab/Tab";
 import SubTitle from "./component/SubTitle/SubTitle";
 import Slides from "./component/bottom/Slides";
 import GlobalStyle from "./style/globalStyle";
+import React, { useState, useEffect } from "react";
 import Modal from "./component/modal/Modal.js";
+import { ModalContext } from "./store/store.js";
 
 const Container = styled.div`
   width: 1440px;
   margin: 0 auto;
 `;
 function App() {
+  const [modalisDisplayed, setModalIsDisplayed] = useState(false);
+  const [clickedId, setClickedId] = useState(1);
+
   return (
     <>
       <GlobalStyle />
       <ThemeProvider theme={theme}>
-        <Container>
-          <Header />
-          <SubTitle />
-          <Tab />
-          <Slides />
-        </Container>
-        <Modal />
+        <ModalContext.Provider
+          value={{
+            isDisplayed: modalisDisplayed,
+            clickedId: clickedId,
+            setClickedId: setClickedId,
+            setModalIsDisplayed: setModalIsDisplayed,
+          }}
+        >
+          <Container>
+            <Header />
+            <SubTitle />
+            <Tab />
+            <Slides />
+            <Modal />
+          </Container>
+        </ModalContext.Provider>
       </ThemeProvider>
     </>
   );

--- a/fe/src/component/Tab/Tab.js
+++ b/fe/src/component/Tab/Tab.js
@@ -1,8 +1,10 @@
 import Card from "../UI/Card";
 import CardsWrapper from "../UI/CardsWrapper";
 import styled from "styled-components";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import constansts from "../../constants/constansts";
+import Modal from "../modal/Modal";
+import { ModalContext } from "../../store/store";
 
 const TabList = styled.ul`
   display: flex;
@@ -19,36 +21,61 @@ const TabListItem = styled.li`
   }
 `;
 
-const Tab = () => {
+const Tab = (props) => {
   const [cards, setCards] = useState([]);
-  const [activeTab, setActiveTab] = useState(1);
+  const [activeTab, setActiveTab] = useState(0);
 
   useEffect(() => {
-    fetch("http://15.165.204.34:8080/api/v1/products/반찬/영양", {
-      headers: {
-        Origin: "http://15.165.204.34:8080/",
-        mode: "no-cors",
-        // "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-    })
-      .then((r) => r.json())
-      .then((r) => console.log(r));
-
-    console.log(1);
-  }, []);
-
-  // headers: {
-  //   "Content-Type": "application/json",
-  //   Accept: "application/json",
-  // },
+    fetch(
+      `${constansts.MAIN_API_URL + constansts.tapInforList[activeTab].postfix}`,
+      {
+        headers: {
+          Origin: "http://15.165.204.34:8080/",
+          mode: "no-cors",
+          Accept: "application/json",
+        },
+      }
+    )
+      .then((res) => res.json())
+      .then((cardData) => setCards(cardData.data));
+  }, [activeTab]);
 
   const onClickHandler = ({ target }) => {
     setActiveTab(+target.id);
   };
 
+  // const ctx = useContext(ModalContext);
+  // console.log(ctx);
+  // const [modalIsDisplayed, setModalIsDisplayed] = useState(false);
+  // const [modalId, setModalId] = useState(1);
+  // const [modalInfo, setModalInfo] = useState([]);
+
+  // const cardClickHandler = (event) => {
+  //   setModalIsDisplayed(true);
+  //   setModalId(event.target.id);
+  // };
+
+  // useEffect(() => {
+  //   fetch(`http://15.165.204.34:8080/api/v1/products/${modalId}/detail`)
+  //     .then((res) => res.json())
+  //     .then((data) => setModalInfo(data.data));
+  // }, [modalId]);
+  // const onCloseModalDisplay = () => {
+  //   setModalIsDisplayed(false);
+  // };
+
   return (
     <>
+      {/* <Modal
+        description={modalInfo.content}
+        discountPrice={modalInfo.discountPrice}
+        originPrice={modalInfo.price}
+        title={modalInfo.name}
+        isDisplayed={modalIsDisplayed}
+        image={modalInfo.imgUrl}
+        shipInfo={modalInfo.shippingInfo}
+        onSaveCloseisClicked={onCloseModalDisplay}
+      /> */}
       <TabList>
         {constansts.tapInforList.map((v) => {
           return (
@@ -65,18 +92,19 @@ const Tab = () => {
       </TabList>
 
       <CardsWrapper>
-        <Card
-          id={cards.detail_hash}
-          key={cards.detail_hash}
-          image={cards.image}
-          alt={cards.alt}
-          title={cards.title}
-          description={cards.description}
-          s_price={cards.s_price}
-          n_price={cards.n_price}
-          badge={cards.badge}
-          delivery={cards.delivery_type}
-        />
+        {cards.map((v) => (
+          <Card
+            id={v.id}
+            key={v.id}
+            image={v.imgUrl}
+            alt={v.name}
+            title={v.name}
+            description={v.content}
+            discountPrice={v.discountPrice}
+            originPrice={v.price}
+            badge={v.applyEvent}
+          />
+        ))}
       </CardsWrapper>
     </>
   );

--- a/fe/src/component/Tab/Tab.js
+++ b/fe/src/component/Tab/Tab.js
@@ -1,10 +1,9 @@
 import Card from "../UI/Card";
 import CardsWrapper from "../UI/CardsWrapper";
 import styled from "styled-components";
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState } from "react";
 import constansts from "../../constants/constansts";
-import Modal from "../modal/Modal";
-import { ModalContext } from "../../store/store";
+import { myfetch } from "../../utils/utils";
 
 const TabList = styled.ul`
   display: flex;
@@ -21,61 +20,22 @@ const TabListItem = styled.li`
   }
 `;
 
-const Tab = (props) => {
+const Tab = () => {
   const [cards, setCards] = useState([]);
   const [activeTab, setActiveTab] = useState(0);
 
   useEffect(() => {
-    fetch(
-      `${constansts.MAIN_API_URL + constansts.tapInforList[activeTab].postfix}`,
-      {
-        headers: {
-          Origin: "http://15.165.204.34:8080/",
-          mode: "no-cors",
-          Accept: "application/json",
-        },
-      }
-    )
-      .then((res) => res.json())
-      .then((cardData) => setCards(cardData.data));
+    myfetch(
+      `${constansts.MAIN_API_URL + constansts.tapInforList[activeTab].postfix}`
+    ).then((cardData) => setCards(cardData.data));
   }, [activeTab]);
 
   const onClickHandler = ({ target }) => {
-    setActiveTab(+target.id);
+    setActiveTab(Number(target.id));
   };
-
-  // const ctx = useContext(ModalContext);
-  // console.log(ctx);
-  // const [modalIsDisplayed, setModalIsDisplayed] = useState(false);
-  // const [modalId, setModalId] = useState(1);
-  // const [modalInfo, setModalInfo] = useState([]);
-
-  // const cardClickHandler = (event) => {
-  //   setModalIsDisplayed(true);
-  //   setModalId(event.target.id);
-  // };
-
-  // useEffect(() => {
-  //   fetch(`http://15.165.204.34:8080/api/v1/products/${modalId}/detail`)
-  //     .then((res) => res.json())
-  //     .then((data) => setModalInfo(data.data));
-  // }, [modalId]);
-  // const onCloseModalDisplay = () => {
-  //   setModalIsDisplayed(false);
-  // };
 
   return (
     <>
-      {/* <Modal
-        description={modalInfo.content}
-        discountPrice={modalInfo.discountPrice}
-        originPrice={modalInfo.price}
-        title={modalInfo.name}
-        isDisplayed={modalIsDisplayed}
-        image={modalInfo.imgUrl}
-        shipInfo={modalInfo.shippingInfo}
-        onSaveCloseisClicked={onCloseModalDisplay}
-      /> */}
       <TabList>
         {constansts.tapInforList.map((v) => {
           return (

--- a/fe/src/component/UI/Card.js
+++ b/fe/src/component/UI/Card.js
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useContext } from "react";
 import styled, { css } from "styled-components";
+import { ModalContext } from "../../store/store";
 import StyledDeliveryIcon from "../icons/DeliveryIcon";
-
+import { priceToString } from "../../utils/utils";
 const CardImg = styled.img`
   ${({ size }) =>
     size === "small"
@@ -85,33 +86,44 @@ const CardWrapper = styled.div`
 `;
 
 const Card = (props) => {
+  const ctx = useContext(ModalContext);
+  const click = ({ target }) => {
+    ctx.setClickedId((prev) => (prev !== target.id ? target.id : prev));
+    ctx.setModalIsDisplayed(true);
+  };
+
   return (
-    <CardWrapper>
-      <CardImg
-        src={props.image}
-        alt={props.alt}
-        size={props.size}
-        id={props.id}
-        onClick={props.onSaveClickedId}
-      />
-      <CardTitle size={props.size}>{props.title}</CardTitle>
-      <CardDesc>{props.description}</CardDesc>
-      <span>{props.s_price}</span>
-      <CardOriginalPrice>{props.n_price}</CardOriginalPrice>
-      <CardBadgeWapper>
-        {!props.badge
-          ? ""
-          : props.badge.map((v, i) => (
+    <>
+      <CardWrapper>
+        <CardImg
+          src={props.image}
+          alt={props.alt}
+          size={props.size}
+          id={props.id}
+          onClick={click}
+        />
+        <CardTitle size={props.size}>{props.title}</CardTitle>
+        <CardDesc>{props.description}</CardDesc>
+        <span>
+          {props.discountPrice && `${priceToString(props.discountPrice)}`}
+        </span>
+        <CardOriginalPrice>
+          {props.originPrice && `${priceToString(props.originPrice)}`}
+        </CardOriginalPrice>
+        <CardBadgeWapper>
+          {props.badge &&
+            props.badge.split(",").map((v, i) => (
               <CardBadge info={v} key={i}>
                 {v}
               </CardBadge>
             ))}
-      </CardBadgeWapper>
-      <StyledDeliveryIcon
-        className={!!props.delivery && "deliveryIconIsActive"}
-        size={props.size}
-      />
-    </CardWrapper>
+        </CardBadgeWapper>
+        <StyledDeliveryIcon
+          className={"deliveryIconIsActive"}
+          size={props.size}
+        />
+      </CardWrapper>
+    </>
   );
 };
 

--- a/fe/src/component/UI/Card.js
+++ b/fe/src/component/UI/Card.js
@@ -3,6 +3,7 @@ import styled, { css } from "styled-components";
 import { ModalContext } from "../../store/store";
 import StyledDeliveryIcon from "../icons/DeliveryIcon";
 import { priceToString } from "../../utils/utils";
+
 const CardImg = styled.img`
   ${({ size }) =>
     size === "small"

--- a/fe/src/component/UI/CardsWrapper.js
+++ b/fe/src/component/UI/CardsWrapper.js
@@ -1,4 +1,4 @@
-import React from "react";
+
 import styled from "styled-components";
 
 const CardsWrapper = styled.div`

--- a/fe/src/component/bottom/More.js
+++ b/fe/src/component/bottom/More.js
@@ -14,7 +14,6 @@ const StyledBtn = styled.button`
   border: 1px dotted ${({ theme }) => theme.colors.grey1};
   font-size: ${({ theme }) => theme.fontSize.large};
   margin: 0 auto;
-  // z-index: 99;
 `;
 
 const More = ({ onchange, isDisplayed }) => {

--- a/fe/src/component/bottom/Slide.js
+++ b/fe/src/component/bottom/Slide.js
@@ -56,14 +56,12 @@ const Slide = ({ title, cardData, alwaysDisplayed, isDisplayed }) => {
     >
       <SlideTitle>{title}</SlideTitle>
       <SlideCardWrapper>
-        <SlideCardsList
-          currentTranslateX={cardListTranslateX.toString() + "px"}
-        >
+        <SlideCardsList currentTranslateX={`${cardListTranslateX}px`}>
           {cardData.map((v) => {
             return (
               <Card
-                id={v.id}
                 size="small"
+                id={v.id}
                 key={v.id}
                 image={v.imgUrl}
                 alt={v.name}

--- a/fe/src/component/bottom/Slide.js
+++ b/fe/src/component/bottom/Slide.js
@@ -33,10 +33,10 @@ const SlideCardsList = styled.div`
   transform: translateX(${({ currentTranslateX }) => currentTranslateX});
 `;
 
-const Slide = ({ cardData, alwaysDisplayed, isDisplayed }) => {
+const Slide = ({ title, cardData, alwaysDisplayed, isDisplayed }) => {
   const [cardListTranslateX, setCardListTranslateX] = useState(0);
   const cardSize = constansts.CardSize.small;
-  const maxTranslateX = -(cardData.body.length * cardSize) + 4 * cardSize;
+  const maxTranslateX = -(cardData.length * cardSize) + 4 * cardSize;
   const onClickRightHandler = () => {
     setCardListTranslateX((prev) =>
       prev - cardSize >= maxTranslateX ? prev - cardSize : prev
@@ -49,35 +49,29 @@ const Slide = ({ cardData, alwaysDisplayed, isDisplayed }) => {
     );
   };
 
-  const click = (event, props) => {
-    console.log(event.target.id);
-  };
-
   return (
     <SlideWrapper
       className={isDisplayed ? "active" : ""}
       style={{ display: alwaysDisplayed && "block" }}
     >
-      <SlideTitle>식탁을 풍성하게 하는 정갈한 밑반찬</SlideTitle>
+      <SlideTitle>{title}</SlideTitle>
       <SlideCardWrapper>
         <SlideCardsList
           currentTranslateX={cardListTranslateX.toString() + "px"}
         >
-          {cardData.body.map((v) => {
+          {cardData.map((v) => {
             return (
               <Card
-                id={v.detail_hash}
+                id={v.id}
                 size="small"
-                key={v.detail_hash}
-                image={v.image}
-                alt={v.alt}
-                title={v.title}
-                description={v.description}
-                s_price={v.s_price}
-                n_price={v.n_price}
-                badge={v.badge}
-                delivery={v.delivery_type}
-                onSaveClickedId={click}
+                key={v.id}
+                image={v.imgUrl}
+                alt={v.name}
+                title={v.name}
+                description={v.content}
+                discountPrice={v.discountPrice}
+                originPrice={v.price}
+                badge={v.applyEvent}
               />
             );
           })}

--- a/fe/src/component/bottom/Slides.js
+++ b/fe/src/component/bottom/Slides.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import Slide from "./Slide";
 import More from "./More";
+import constansts from "../../constants/constansts";
+import Modal from "../modal/Modal";
 
 const Slides = () => {
   const [cardsInfor, setCardInfor] = useState([]);
@@ -10,32 +12,34 @@ const Slides = () => {
   };
 
   useEffect(() => {
-    const url = [
-      "https://api.codesquad.kr/onban/side",
-      "https://api.codesquad.kr/onban/soup",
-      "https://api.codesquad.kr/onban/main",
-    ];
-
-    const data = Promise.all(
-      url.map(async (v) => {
-        return await myfetch(v);
-      })
+    const url = constansts.SlideINfor.map(
+      (v) => `${constansts.MAIN_API_URL}${v.postfix}`
     );
-
-    data.then((res) => setCardInfor(res));
+    const data = Promise.all(url.map(myfetch));
+    data
+      .then((res) =>
+        constansts.SlideINfor.map((v, i) =>
+          Object.assign(v, {
+            data: res[i].data,
+          })
+        )
+      )
+      .then((data) => setCardInfor(data));
   }, []);
 
   const onChangeSlideDisplay = () => {
     isDisplayed ? setIsDisplayed(false) : setIsDisplayed(true);
   };
+
   return (
     <>
       {cardsInfor.map((v, i) => (
         <Slide
-          cardData={v}
-          key={i}
-          alwaysDisplayed={i === 0 ? true : false}
+          cardData={v.data}
+          key={v.id}
+          alwaysDisplayed={i === 0}
           isDisplayed={isDisplayed}
+          title={v.title}
         />
       ))}
       <More onchange={onChangeSlideDisplay} isDisplayed={isDisplayed} />

--- a/fe/src/component/bottom/Slides.js
+++ b/fe/src/component/bottom/Slides.js
@@ -2,19 +2,17 @@ import React, { useState, useEffect } from "react";
 import Slide from "./Slide";
 import More from "./More";
 import constansts from "../../constants/constansts";
-import Modal from "../modal/Modal";
+import { myfetch } from "../../utils/utils";
 
 const Slides = () => {
   const [cardsInfor, setCardInfor] = useState([]);
   const [isDisplayed, setIsDisplayed] = useState(false);
-  const myfetch = (url) => {
-    return fetch(url).then((res) => res.json());
-  };
 
   useEffect(() => {
     const url = constansts.SlideINfor.map(
       (v) => `${constansts.MAIN_API_URL}${v.postfix}`
     );
+
     const data = Promise.all(url.map(myfetch));
     data
       .then((res) =>
@@ -28,7 +26,7 @@ const Slides = () => {
   }, []);
 
   const onChangeSlideDisplay = () => {
-    isDisplayed ? setIsDisplayed(false) : setIsDisplayed(true);
+    setIsDisplayed(!isDisplayed);
   };
 
   return (

--- a/fe/src/component/modal/DetailImage.js
+++ b/fe/src/component/modal/DetailImage.js
@@ -22,10 +22,10 @@ const SmallImg = styled.img`
   margin-right: 3px;
 `;
 
-const DetailImage = () => {
+const DetailImage = ({ image }) => {
   return (
     <ImageWrapper>
-      <TopImg src="http://public.codesquad.kr/jk/storeapp/data/main/510_ZIP_P_0047_T.jpg" />
+      <TopImg src={image} />
       <SmallImgWrapper>
         <SmallImg src="https://public.codesquad.kr/jk/storeapp/data/main/510_ZIP_P_0047_S.jpg" />
         <SmallImg src="http://public.codesquad.kr/jk/storeapp/data/main/510_ZIP_P_0047_T.jpg" />

--- a/fe/src/component/modal/DetailImage.js
+++ b/fe/src/component/modal/DetailImage.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState, useContext, useEffect } from "react";
+import { ModalContext } from "../../store/store";
 import styled from "styled-components";
 
 const ImageWrapper = styled.div`
@@ -23,12 +24,28 @@ const SmallImg = styled.img`
 `;
 
 const DetailImage = ({ image }) => {
+  const ctx = useContext(ModalContext);
+  useEffect(() => {
+    ctx.isDisplayed && setCurrentImg(image[0]);
+  }, [ctx.isDisplayed, image]);
+
+  const [currentImg, setCurrentImg] = useState(
+    Array.isArray(image) ? image[0] : image
+  );
+
+  const onChangeImg = (event) => {
+    setCurrentImg(event.target.src);
+  };
+
+  // 모달 absolute vw , vh 로 재설정
   return (
     <ImageWrapper>
-      <TopImg src={image} />
+      <TopImg src={currentImg} />
       <SmallImgWrapper>
-        <SmallImg src="https://public.codesquad.kr/jk/storeapp/data/main/510_ZIP_P_0047_S.jpg" />
-        <SmallImg src="http://public.codesquad.kr/jk/storeapp/data/main/510_ZIP_P_0047_T.jpg" />
+        {image &&
+          image.map((v) => (
+            <SmallImg src={v} key={v} imgUrl={v} onClick={onChangeImg} />
+          ))}
       </SmallImgWrapper>
     </ImageWrapper>
   );

--- a/fe/src/component/modal/DetailInfo.js
+++ b/fe/src/component/modal/DetailInfo.js
@@ -57,8 +57,6 @@ const ProductInfoWrapper = styled.div`
   padding-bottom: 15px;
 `;
 
-// ProductInfoWrapper
-
 const ProductPriceWrapper = styled.div`
   display: flex;
   height: 80px;
@@ -96,7 +94,6 @@ const ProductAmountCountWrapper = styled.div`
   height: 30px;
   justify-content: space-between;
   align-items: center;
-
   display: flex;
 `;
 

--- a/fe/src/component/modal/DetailInfo.js
+++ b/fe/src/component/modal/DetailInfo.js
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import styled, { css } from "styled-components";
 import { PlusIcon, MinusIcon } from "../icons/ModalIcon";
+import { priceToString } from "../../utils/utils";
 
 const InforWrapper = styled.div`
   width: 470px;
@@ -121,15 +122,25 @@ const OrderButton = styled.button`
   color: wheat;
 `;
 
-const DetailInfo = () => {
+const DetailInfo = ({ infoData }) => {
+  const [orderNumber, SetOrderNumber] = useState(1);
+
+  const orderNumberMinus = () => {
+    SetOrderNumber((prev) => (prev === 1 ? prev : prev - 1));
+  };
+
+  const orderNumberPlus = () => {
+    SetOrderNumber((prev) => prev + 1);
+  };
+
   return (
     <InforWrapper>
       <TextWrapper>
         <ProductInfoWrapper>
-          <InforTitle>오리주물럭_반조리</InforTitle>
-          <InforOriginPrice>15,800원</InforOriginPrice>
+          <InforTitle>{infoData.name}</InforTitle>
+          <InforOriginPrice>{priceToString(infoData.price)}</InforOriginPrice>
           <InforBadge>런칭특가</InforBadge>
-          <SaledPrice>12,640원</SaledPrice>
+          <SaledPrice>{priceToString(infoData.discountPrice)}</SaledPrice>
         </ProductInfoWrapper>
 
         <ProductPriceWrapper>
@@ -140,25 +151,31 @@ const DetailInfo = () => {
           </ProductPriceTextWrapper>
 
           <ProductPriceTextWrapper>
-            <ProductPriceText>125원</ProductPriceText>
             <ProductPriceText>
-              서울 경기 새벽 배송 / 전국 택배 배송
+              {Math.floor(infoData.discountPrice * 0.01).toString()}
             </ProductPriceText>
             <ProductPriceText>
-              2,500원 (40,000원 이상 구매 시 무료)
+              {infoData.shippingInfo && infoData.shippingInfo.deliveryInfo}
+            </ProductPriceText>
+            <ProductPriceText>
+              {infoData.shipInfo &&
+                infoData.shipInfo.deliveryCharge.toString() + " "}
+              (40,000원 이상 구매 시 무료)
             </ProductPriceText>
           </ProductPriceTextWrapper>
         </ProductPriceWrapper>
 
         <ProductAmountWrapper>
           <ProductAmountCountWrapper>
-            <MinusIcon />
-            <ProductAmountCount>1</ProductAmountCount>
-            <PlusIcon />
+            <MinusIcon onClick={orderNumberMinus} />
+            <ProductAmountCount>{orderNumber}</ProductAmountCount>
+            <PlusIcon onClick={orderNumberPlus} />
           </ProductAmountCountWrapper>
           <div>
             <ProductAmountText>총 주문금액</ProductAmountText>
-            <ProductAmount>12,640원</ProductAmount>
+            <ProductAmount>
+              {priceToString(infoData.discountPrice * orderNumber)}
+            </ProductAmount>
           </div>
         </ProductAmountWrapper>
         <OrderButton>주문하기</OrderButton>

--- a/fe/src/component/modal/DetailInfo.js
+++ b/fe/src/component/modal/DetailInfo.js
@@ -123,15 +123,34 @@ const OrderButton = styled.button`
 const DetailInfo = ({ infoData }) => {
   const [orderNumber, SetOrderNumber] = useState(1);
   const ctx = useContext(ModalContext);
+
   useEffect(() => {
     !ctx.isDisplayed && SetOrderNumber(1);
   }, [ctx.isDisplayed]);
+
   const orderNumberMinus = () => {
     SetOrderNumber((prev) => (prev === 1 ? prev : prev - 1));
   };
 
   const orderNumberPlus = () => {
     SetOrderNumber((prev) => prev + 1);
+  };
+
+  const order = () => {
+    const orderData = {
+      id: `${ctx.clickedId}`,
+      quantity: `${orderNumber}`,
+    };
+    fetch("http://15.165.204.34:8080/api/v1/products/orders", {
+      method: "post",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(orderData),
+    });
+
+    alert(`주문 성공했습니다!`);
   };
 
   return (
@@ -179,7 +198,7 @@ const DetailInfo = ({ infoData }) => {
             </ProductAmount>
           </div>
         </ProductAmountWrapper>
-        <OrderButton>주문하기</OrderButton>
+        <OrderButton onClick={order}>주문하기</OrderButton>
       </TextWrapper>
     </InforWrapper>
   );

--- a/fe/src/component/modal/DetailInfo.js
+++ b/fe/src/component/modal/DetailInfo.js
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import styled, { css } from "styled-components";
 import { PlusIcon, MinusIcon } from "../icons/ModalIcon";
 import { priceToString } from "../../utils/utils";
+import { ModalContext } from "../../store/store";
 
 const InforWrapper = styled.div`
   width: 470px;
@@ -121,7 +122,10 @@ const OrderButton = styled.button`
 
 const DetailInfo = ({ infoData }) => {
   const [orderNumber, SetOrderNumber] = useState(1);
-
+  const ctx = useContext(ModalContext);
+  useEffect(() => {
+    !ctx.isDisplayed && SetOrderNumber(1);
+  }, [ctx.isDisplayed]);
   const orderNumberMinus = () => {
     SetOrderNumber((prev) => (prev === 1 ? prev : prev - 1));
   };
@@ -155,8 +159,8 @@ const DetailInfo = ({ infoData }) => {
               {infoData.shippingInfo && infoData.shippingInfo.deliveryInfo}
             </ProductPriceText>
             <ProductPriceText>
-              {infoData.shipInfo &&
-                infoData.shipInfo.deliveryCharge.toString() + " "}
+              {infoData.shippingInfo &&
+                infoData.shippingInfo.deliveryCharge.toString() + " "}
               (40,000원 이상 구매 시 무료)
             </ProductPriceText>
           </ProductPriceTextWrapper>

--- a/fe/src/component/modal/Modal.js
+++ b/fe/src/component/modal/Modal.js
@@ -4,6 +4,8 @@ import styled from "styled-components";
 import ProductDetails from "./ProductDetail";
 import ModalSlider from "./ModalSlider";
 import { ModalContext } from "../../store/store";
+import { myfetch } from "../../utils/utils";
+
 const ModalWrapper = styled.div`
   width: 900px;
   height: 794px;
@@ -13,6 +15,7 @@ const ModalWrapper = styled.div`
   top: 20%;
   left: 20%;
   padding: 50px 30px;
+  z-index: 99;
   &.hidden {
     display: none;
   }
@@ -26,7 +29,7 @@ const ModalCloseButton = styled.button`
   color: #777;
 `;
 
-const Modal = (props) => {
+const Modal = () => {
   const ctx = useContext(ModalContext);
   const onClickHandler = () => {
     ctx.setModalIsDisplayed(false);
@@ -35,9 +38,9 @@ const Modal = (props) => {
   const [modalInfor, setModalInfor] = useState([]);
 
   useEffect(() => {
-    fetch(`http://15.165.204.34:8080/api/v1/products/${ctx.clickedId}/detail`)
-      .then((res) => res.json())
-      .then((data) => setModalInfor(data.data));
+    myfetch(
+      `http://15.165.204.34:8080/api/v1/products/${ctx.clickedId}/detail`
+    ).then((data) => setModalInfor(data.data));
   }, [ctx.clickedId]);
 
   return (

--- a/fe/src/component/modal/Modal.js
+++ b/fe/src/component/modal/Modal.js
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
 import ProductDetails from "./ProductDetail";
 import ModalSlider from "./ModalSlider";
-
+import { ModalContext } from "../../store/store";
 const ModalWrapper = styled.div`
   width: 900px;
   height: 794px;
@@ -13,7 +13,6 @@ const ModalWrapper = styled.div`
   top: 20%;
   left: 20%;
   padding: 50px 30px;
-
   &.hidden {
     display: none;
   }
@@ -27,20 +26,27 @@ const ModalCloseButton = styled.button`
   color: #777;
 `;
 
-const Modal = () => {
-  const [isDisplayed, setIsDisplayed] = useState(true);
-  const closeBtnClickHandler = () => {
-    setIsDisplayed(false);
+const Modal = (props) => {
+  const ctx = useContext(ModalContext);
+  const onClickHandler = () => {
+    ctx.setModalIsDisplayed(false);
   };
+
+  const [modalInfor, setModalInfor] = useState([]);
+
+  useEffect(() => {
+    fetch(`http://15.165.204.34:8080/api/v1/products/${ctx.clickedId}/detail`)
+      .then((res) => res.json())
+      .then((data) => setModalInfor(data.data));
+  }, [ctx.clickedId]);
+
   return (
     <>
       {ReactDOM.createPortal(
-        <ModalWrapper className={isDisplayed ? "" : "hidden"}>
-          <ProductDetails />
+        <ModalWrapper className={ctx.isDisplayed ? "" : "hidden"}>
+          <ProductDetails data={modalInfor} />
           <ModalSlider />
-          <ModalCloseButton onClick={closeBtnClickHandler}>
-            닫기
-          </ModalCloseButton>
+          <ModalCloseButton onClick={onClickHandler}>닫기</ModalCloseButton>
         </ModalWrapper>,
         document.getElementById("modal")
       )}

--- a/fe/src/component/modal/Modal.js
+++ b/fe/src/component/modal/Modal.js
@@ -10,12 +10,13 @@ const ModalWrapper = styled.div`
   width: 900px;
   height: 794px;
   border: 1px solid #000;
-  position: absolute;
+  position: fixed;
   background: #fff;
-  top: 20%;
-  left: 20%;
+  top: 50%;
+  left: 50%;
   padding: 50px 30px;
   z-index: 99;
+  transform: translate(-50%, -50%);
   &.hidden {
     display: none;
   }
@@ -34,13 +35,14 @@ const Modal = () => {
   const onClickHandler = () => {
     ctx.setModalIsDisplayed(false);
   };
-
   const [modalInfor, setModalInfor] = useState([]);
 
   useEffect(() => {
     myfetch(
       `http://15.165.204.34:8080/api/v1/products/${ctx.clickedId}/detail`
-    ).then((data) => setModalInfor(data.data));
+    ).then((data) => {
+      setModalInfor(data.data);
+    });
   }, [ctx.clickedId]);
 
   return (

--- a/fe/src/component/modal/ModalSlider.js
+++ b/fe/src/component/modal/ModalSlider.js
@@ -48,12 +48,12 @@ const ModalSlider = () => {
   const [cards, setCards] = useState([]);
   const [cardListTranslateX, setCardListTranslateX] = useState(0);
   const [pageNum, setPageNum] = useState(1);
-  useEffect(() => {
-    fetch("https://api.codesquad.kr/onban/side")
-      .then((res) => res.json())
-      .then((res) => setCards(res.body));
-  }, []);
 
+  useEffect(() => {
+    fetch("http://15.165.204.34:8080/api/v1/products/반찬")
+      .then((res) => res.json())
+      .then((res) => setCards(res.data));
+  }, []);
   const max = -920;
   const maxPage = Math.ceil((166 * cards.length) / 895);
 
@@ -94,13 +94,14 @@ const ModalSlider = () => {
         >
           {cards.map((v) => (
             <Card
+              id={v.id}
+              key={v.id}
+              image={v.imgUrl}
+              alt={v.name}
+              title={v.name}
+              discountPrice={v.discountPrice}
+              originPrice={v.price}
               size="xSmall"
-              key={v.detail_hash}
-              image={v.image}
-              alt={v.alt}
-              title={v.title}
-              s_price={v.s_price}
-              n_price={v.n_price}
             />
           ))}
         </SlideCardsList>

--- a/fe/src/component/modal/ModalSlider.js
+++ b/fe/src/component/modal/ModalSlider.js
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import Card from "../UI/Card";
 import { useState, useEffect } from "react";
 import { LeftIcon, RightIcon } from "../icons/SlideIcon";
+import { myfetch } from "../../utils/utils";
 
 const ModalSlideWrppaer = styled.div`
   height: 313px;
@@ -50,9 +51,9 @@ const ModalSlider = () => {
   const [pageNum, setPageNum] = useState(1);
 
   useEffect(() => {
-    fetch("http://15.165.204.34:8080/api/v1/products/반찬")
-      .then((res) => res.json())
-      .then((res) => setCards(res.data));
+    myfetch("http://15.165.204.34:8080/api/v1/products/반찬").then((res) =>
+      setCards(res.data)
+    );
   }, []);
   const max = -920;
   const maxPage = Math.ceil((166 * cards.length) / 895);

--- a/fe/src/component/modal/ProductDetail.js
+++ b/fe/src/component/modal/ProductDetail.js
@@ -10,11 +10,11 @@ const ProductDetail = styled.div`
   border-bottom: 1px solid black;
 `;
 
-const ProductDetails = () => {
+const ProductDetails = ({ data }) => {
   return (
     <ProductDetail>
-      <DetailImage />
-      <DetailInfo />
+      <DetailImage image={data.imgUrl} />
+      <DetailInfo infoData={data} />
     </ProductDetail>
   );
 };

--- a/fe/src/constants/constansts.js
+++ b/fe/src/constants/constansts.js
@@ -7,21 +7,60 @@ const GNBLists = [
   },
 ];
 
+const MAIN_API_URL = "http://15.165.204.34:8080/api/v1/products/";
+
 const tapInforList = [
-  { id: 1, title: "풍성한 고기반찬" },
-  { id: 2, title: "편리한 반찬세트" },
-  { id: 3, title: "맛있는 제철요리" },
-  { id: 4, title: "우리 아이 영향 반찬" },
+  {
+    id: 0,
+    title: "우리 아이 영양 반찬",
+    postfix: "반찬/영양",
+  },
+  {
+    id: 1,
+    title: "편리한 반찬세트",
+    postfix: "반찬/편리",
+  },
+  {
+    id: 2,
+    title: "맛있는 제철요리",
+    postfix: "반찬/제철",
+  },
+  {
+    id: 3,
+    title: "풍성한 고기반찬",
+    postfix: "반찬/고기",
+  },
 ];
 
 const CardSize = {
   small: 320,
   big: 420,
 };
+
+const SlideINfor = [
+  {
+    id: 0,
+    title: "든든한 메인요리",
+    postfix: "메인",
+  },
+  {
+    id: 1,
+    title: "정갈한 밑반찬",
+    postfix: "반찬",
+  },
+  {
+    id: 2,
+    title: "뜨끈한 국물요리",
+    postfix: "국물",
+  },
+];
+
 const constansts = {
   GNBLists,
   tapInforList,
   CardSize,
+  SlideINfor,
+  MAIN_API_URL,
 };
 
 export default constansts;

--- a/fe/src/store/store.js
+++ b/fe/src/store/store.js
@@ -1,0 +1,8 @@
+import React, { createContext } from "react";
+
+const ModalContext = createContext({
+  isDisplayed: false,
+  clickedCardId: 1,
+});
+
+export { ModalContext };

--- a/fe/src/utils/utils.js
+++ b/fe/src/utils/utils.js
@@ -4,4 +4,15 @@ const priceToString = (price) => {
     : Number(price).toLocaleString() + "원";
 };
 
-export { priceToString };
+const fetch_config = {
+  headers: {
+    Origin: "http://15.165.204.34:8080/",
+    mode: "no-cors",
+    Accept: "application/json",
+  },
+};
+
+const myfetch = (url) => {
+  return fetch(url, fetch_config).then((res) => res.json());
+};
+export { priceToString, fetch_config, myfetch };

--- a/fe/src/utils/utils.js
+++ b/fe/src/utils/utils.js
@@ -1,0 +1,7 @@
+const priceToString = (price) => {
+  return typeof price === Number
+    ? price.toLocaleString() + "원"
+    : Number(price).toLocaleString() + "원";
+};
+
+export { priceToString };


### PR DESCRIPTION
### 새로 구현한 내용
- 카드 이미지 클릭 -> 모달창 출력
- 모달창은 사용자 입장에서 항상 가운데로 출력하도록 설정
- 모달창 상세 이미지 클릭시 메인 이미지 변경
- 모달창 +, - 시 가격 변동
- 백엔드 API로 데이터 불러오기

### 미구현 사항
- `styled component` 로 분기처리해서 `custom div` 사용하기
- 시간이 부족해서, 이번 미션 후 공부해보기로 했습니다 😂

### 모달창 관련
- 원래는 `useContext`를 사용하지 않고, `Modal`을 불러오는 곳에서 `Modal`을 출력하고자 하였는데
  `Tap`과, 아래 `Slide`에서 `Modal`을 불러와야해서 중복이 생기는 문제가 있었습니다.
  처음에 설계할때 카드들만을 담는 공통적인 요소를 하나 두었다면 문제가 없었을 것 같은데, 이러한 문제로 `useContext`를 사용해서
  모달 처리를 했습니다.
- `order` 기능을 추가했지만, `order` 모달을 따로 구현하지는 못했습니다. 
-  백엔드 data의 수량이 줄어드는 것 정도만 확인했습니다.
- `useContext`를 제대로 공부하지 않고 사용해서, 이렇게 사용하는게 맞나..? 싶었습니다. 😂

### 후님에게, 😆
- 후, 매번 꼼꼼한 리뷰 정말정말 감사합니다. 😁
- 덕분에 2주동안 리뷰를 보면서 새로 공부할 내용도 정리했고, 부족한 부분에 대해 잘 알 수 있게 되었습니다!
- 간단히 배포하려고 했는데, 뭔가를 새롭게 설정해주어야 하는 것 같아 일단 동영상으로 대체합니다. 😂

https://user-images.githubusercontent.com/87624756/165889019-6c735032-4d22-4dfe-82fc-17f8059f39cd.mov

 